### PR TITLE
Use pypi.org instead of test.pypi.org for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,4 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
+        twine upload --verbose dist/*


### PR DESCRIPTION
We've tested that publishing to test.pypi.org works fine.
Now we can switch to pypi.org.
Please update credentials in Settings/Secrets as well!