### PR TITLE
Use `find_packages()` in `setup.py` to include all sub-directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     description="PySyft protocol constants.",
-    packages=["syft_proto"],
+    packages=find_packages(),
     package_data={"": ["proto.json"]},
     install_requires=["protobuf>=3.11.1"],
     license="LICENSE",


### PR DESCRIPTION
Otherwise the Protobuf stubs get omitted from the published package.