### PR TITLE
Add GradFunc proto code

### DIFF
--- a/proto.json
+++ b/proto.json
@@ -155,6 +155,9 @@
     },
     "syft.frameworks.torch.tensors.interpreters.private.PrivateTensor": {
       "code": 46
+    },
+    "syft.frameworks.torch.tensors.interpreters.gradients_core.GradFunc": {
+      "code": 47
     }
   }
 }


### PR DESCRIPTION
A new proto code for GradFunc is added.
Used in the serialization of gradient functions.
Related PR: https://github.com/OpenMined/PySyft/pull/2871