### PR TITLE
Stop publishing releases on every push to master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,8 @@
 name: Publish PyPI Package
 
 on:
-  push:
-    branches:
-    - master
-    paths:
-    - 'syft_proto/**'
-    - 'proto.json'
-    - 'setup.cfg'
-    - '*.py'
-    - 'LICENSE'
-    - 'README.md'
-
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
In combination with optimistic dependency specifications, this has been part of the problem that leads to PySyft breaking every time `syft-proto` changes.