### PR TITLE
Add operations & framework for plan translation

### DIFF
--- a/protobuf/syft_proto/execution/v1/plan.proto
+++ b/protobuf/syft_proto/execution/v1/plan.proto
@@ -16,4 +16,6 @@ message Plan {
     string description = 6;
     bytes torchscript = 7;
     NestedTypeWrapper input_types = 8;
+    string base_framework = 9;
+    repeated syft_proto.execution.v1.Role roles = 10;
 }


### PR DESCRIPTION
Plan translation using threepio adds `operations` to `Role` which allows us to store multiple `Action` lists for each framework. It also adds `base_framework` to Plan which indicates which framework `Plan.actions` is targeting.

https://github.com/OpenMined/PySyft/pull/3371 is blocking on this PR 