### PR TITLE
Update fields in `CommunicationAction` proto

### DIFF
--- a/js/protobuf.d.js
+++ b/js/protobuf.d.js
@@ -1837,8 +1837,8 @@ export namespace syft_proto {
                     /** Arg arg_float */
                     arg_float?: (number|null);
 
-                    /** Arg arg_string */
-                    arg_string?: (string|null);
+                    /** Arg arg_str */
+                    arg_str?: (string|null);
 
                     /** Arg arg_shape */
                     arg_shape?: (syft_proto.types.syft.v1.IShape|null);
@@ -1877,8 +1877,8 @@ export namespace syft_proto {
                     /** Arg arg_float. */
                     public arg_float: number;
 
-                    /** Arg arg_string. */
-                    public arg_string: string;
+                    /** Arg arg_str. */
+                    public arg_str: string;
 
                     /** Arg arg_shape. */
                     public arg_shape?: (syft_proto.types.syft.v1.IShape|null);
@@ -1899,7 +1899,7 @@ export namespace syft_proto {
                     public arg_placeholder_id?: (syft_proto.execution.v1.IPlaceholderId|null);
 
                     /** Arg arg. */
-                    public arg?: ("arg_bool"|"arg_int"|"arg_float"|"arg_string"|"arg_shape"|"arg_tensor"|"arg_torch_param"|"arg_pointer_tensor"|"arg_placeholder"|"arg_placeholder_id");
+                    public arg?: ("arg_bool"|"arg_int"|"arg_float"|"arg_str"|"arg_shape"|"arg_tensor"|"arg_torch_param"|"arg_pointer_tensor"|"arg_placeholder"|"arg_placeholder_id");
 
                     /**
                      * Creates a new Arg instance using the specified properties.

--- a/js/protobuf.d.js
+++ b/js/protobuf.d.js
@@ -11,20 +11,32 @@ export namespace syft_proto {
             /** Properties of a CommunicationAction. */
             interface ICommunicationAction {
 
-                /** CommunicationAction name */
-                name?: (string|null);
+                /** CommunicationAction command */
+                command?: (string|null);
 
-                /** CommunicationAction obj_id */
-                obj_id?: (syft_proto.types.syft.v1.IId|null);
+                /** CommunicationAction target_id */
+                target_id?: (syft_proto.types.syft.v1.IId|null);
 
-                /** CommunicationAction source */
-                source?: (syft_proto.types.syft.v1.IId|null);
+                /** CommunicationAction target_pointer */
+                target_pointer?: (syft_proto.generic.pointers.v1.IPointerTensor|null);
 
-                /** CommunicationAction destinations */
-                destinations?: (syft_proto.types.syft.v1.IId[]|null);
+                /** CommunicationAction target_placeholder_id */
+                target_placeholder_id?: (syft_proto.execution.v1.IPlaceholderId|null);
+
+                /** CommunicationAction target_tensor */
+                target_tensor?: (syft_proto.types.torch.v1.ITorchTensor|null);
+
+                /** CommunicationAction args */
+                args?: (syft_proto.types.syft.v1.IArg[]|null);
 
                 /** CommunicationAction kwargs */
                 kwargs?: ({ [k: string]: syft_proto.types.syft.v1.IArg }|null);
+
+                /** CommunicationAction return_ids */
+                return_ids?: (syft_proto.types.syft.v1.IId[]|null);
+
+                /** CommunicationAction return_placeholder_ids */
+                return_placeholder_ids?: (syft_proto.execution.v1.IPlaceholderId[]|null);
             }
 
             /** Represents a CommunicationAction. */
@@ -36,20 +48,35 @@ export namespace syft_proto {
                  */
                 constructor(properties?: syft_proto.execution.v1.ICommunicationAction);
 
-                /** CommunicationAction name. */
-                public name: string;
+                /** CommunicationAction command. */
+                public command: string;
 
-                /** CommunicationAction obj_id. */
-                public obj_id?: (syft_proto.types.syft.v1.IId|null);
+                /** CommunicationAction target_id. */
+                public target_id?: (syft_proto.types.syft.v1.IId|null);
 
-                /** CommunicationAction source. */
-                public source?: (syft_proto.types.syft.v1.IId|null);
+                /** CommunicationAction target_pointer. */
+                public target_pointer?: (syft_proto.generic.pointers.v1.IPointerTensor|null);
 
-                /** CommunicationAction destinations. */
-                public destinations: syft_proto.types.syft.v1.IId[];
+                /** CommunicationAction target_placeholder_id. */
+                public target_placeholder_id?: (syft_proto.execution.v1.IPlaceholderId|null);
+
+                /** CommunicationAction target_tensor. */
+                public target_tensor?: (syft_proto.types.torch.v1.ITorchTensor|null);
+
+                /** CommunicationAction args. */
+                public args: syft_proto.types.syft.v1.IArg[];
 
                 /** CommunicationAction kwargs. */
                 public kwargs: { [k: string]: syft_proto.types.syft.v1.IArg };
+
+                /** CommunicationAction return_ids. */
+                public return_ids: syft_proto.types.syft.v1.IId[];
+
+                /** CommunicationAction return_placeholder_ids. */
+                public return_placeholder_ids: syft_proto.execution.v1.IPlaceholderId[];
+
+                /** CommunicationAction target. */
+                public target?: ("target_id"|"target_pointer"|"target_placeholder_id"|"target_tensor");
 
                 /**
                  * Creates a new CommunicationAction instance using the specified properties.
@@ -117,6 +144,96 @@ export namespace syft_proto {
 
                 /**
                  * Converts this CommunicationAction to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
+            /** Properties of a PlaceholderId. */
+            interface IPlaceholderId {
+
+                /** PlaceholderId id */
+                id?: (syft_proto.types.syft.v1.IId|null);
+            }
+
+            /** Represents a PlaceholderId. */
+            class PlaceholderId implements IPlaceholderId {
+
+                /**
+                 * Constructs a new PlaceholderId.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: syft_proto.execution.v1.IPlaceholderId);
+
+                /** PlaceholderId id. */
+                public id?: (syft_proto.types.syft.v1.IId|null);
+
+                /**
+                 * Creates a new PlaceholderId instance using the specified properties.
+                 * @param [properties] Properties to set
+                 * @returns PlaceholderId instance
+                 */
+                public static create(properties?: syft_proto.execution.v1.IPlaceholderId): syft_proto.execution.v1.PlaceholderId;
+
+                /**
+                 * Encodes the specified PlaceholderId message. Does not implicitly {@link syft_proto.execution.v1.PlaceholderId.verify|verify} messages.
+                 * @param message PlaceholderId message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encode(message: syft_proto.execution.v1.IPlaceholderId, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Encodes the specified PlaceholderId message, length delimited. Does not implicitly {@link syft_proto.execution.v1.PlaceholderId.verify|verify} messages.
+                 * @param message PlaceholderId message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encodeDelimited(message: syft_proto.execution.v1.IPlaceholderId, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Decodes a PlaceholderId message from the specified reader or buffer.
+                 * @param reader Reader or buffer to decode from
+                 * @param [length] Message length if known beforehand
+                 * @returns PlaceholderId
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): syft_proto.execution.v1.PlaceholderId;
+
+                /**
+                 * Decodes a PlaceholderId message from the specified reader or buffer, length delimited.
+                 * @param reader Reader or buffer to decode from
+                 * @returns PlaceholderId
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): syft_proto.execution.v1.PlaceholderId;
+
+                /**
+                 * Verifies a PlaceholderId message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Creates a PlaceholderId message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns PlaceholderId
+                 */
+                public static fromObject(object: { [k: string]: any }): syft_proto.execution.v1.PlaceholderId;
+
+                /**
+                 * Creates a plain object from a PlaceholderId message. Also converts values to other types if specified.
+                 * @param message PlaceholderId
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: syft_proto.execution.v1.PlaceholderId, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this PlaceholderId to JSON.
                  * @returns JSON object
                  */
                 public toJSON(): { [k: string]: any };
@@ -225,96 +342,6 @@ export namespace syft_proto {
 
                 /**
                  * Converts this Placeholder to JSON.
-                 * @returns JSON object
-                 */
-                public toJSON(): { [k: string]: any };
-            }
-
-            /** Properties of a PlaceholderId. */
-            interface IPlaceholderId {
-
-                /** PlaceholderId id */
-                id?: (syft_proto.types.syft.v1.IId|null);
-            }
-
-            /** Represents a PlaceholderId. */
-            class PlaceholderId implements IPlaceholderId {
-
-                /**
-                 * Constructs a new PlaceholderId.
-                 * @param [properties] Properties to set
-                 */
-                constructor(properties?: syft_proto.execution.v1.IPlaceholderId);
-
-                /** PlaceholderId id. */
-                public id?: (syft_proto.types.syft.v1.IId|null);
-
-                /**
-                 * Creates a new PlaceholderId instance using the specified properties.
-                 * @param [properties] Properties to set
-                 * @returns PlaceholderId instance
-                 */
-                public static create(properties?: syft_proto.execution.v1.IPlaceholderId): syft_proto.execution.v1.PlaceholderId;
-
-                /**
-                 * Encodes the specified PlaceholderId message. Does not implicitly {@link syft_proto.execution.v1.PlaceholderId.verify|verify} messages.
-                 * @param message PlaceholderId message or plain object to encode
-                 * @param [writer] Writer to encode to
-                 * @returns Writer
-                 */
-                public static encode(message: syft_proto.execution.v1.IPlaceholderId, writer?: $protobuf.Writer): $protobuf.Writer;
-
-                /**
-                 * Encodes the specified PlaceholderId message, length delimited. Does not implicitly {@link syft_proto.execution.v1.PlaceholderId.verify|verify} messages.
-                 * @param message PlaceholderId message or plain object to encode
-                 * @param [writer] Writer to encode to
-                 * @returns Writer
-                 */
-                public static encodeDelimited(message: syft_proto.execution.v1.IPlaceholderId, writer?: $protobuf.Writer): $protobuf.Writer;
-
-                /**
-                 * Decodes a PlaceholderId message from the specified reader or buffer.
-                 * @param reader Reader or buffer to decode from
-                 * @param [length] Message length if known beforehand
-                 * @returns PlaceholderId
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): syft_proto.execution.v1.PlaceholderId;
-
-                /**
-                 * Decodes a PlaceholderId message from the specified reader or buffer, length delimited.
-                 * @param reader Reader or buffer to decode from
-                 * @returns PlaceholderId
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): syft_proto.execution.v1.PlaceholderId;
-
-                /**
-                 * Verifies a PlaceholderId message.
-                 * @param message Plain object to verify
-                 * @returns `null` if valid, otherwise the reason why it is not
-                 */
-                public static verify(message: { [k: string]: any }): (string|null);
-
-                /**
-                 * Creates a PlaceholderId message from a plain object. Also converts values to their respective internal types.
-                 * @param object Plain object
-                 * @returns PlaceholderId
-                 */
-                public static fromObject(object: { [k: string]: any }): syft_proto.execution.v1.PlaceholderId;
-
-                /**
-                 * Creates a plain object from a PlaceholderId message. Also converts values to other types if specified.
-                 * @param message PlaceholderId
-                 * @param [options] Conversion options
-                 * @returns Plain object
-                 */
-                public static toObject(message: syft_proto.execution.v1.PlaceholderId, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-                /**
-                 * Converts this PlaceholderId to JSON.
                  * @returns JSON object
                  */
                 public toJSON(): { [k: string]: any };
@@ -1609,153 +1636,6 @@ export namespace syft_proto {
             /** Namespace v1. */
             namespace v1 {
 
-                /** Properties of an Arg. */
-                interface IArg {
-
-                    /** Arg arg_bool */
-                    arg_bool?: (boolean|null);
-
-                    /** Arg arg_int */
-                    arg_int?: (number|null);
-
-                    /** Arg arg_float */
-                    arg_float?: (number|null);
-
-                    /** Arg arg_string */
-                    arg_string?: (string|null);
-
-                    /** Arg arg_shape */
-                    arg_shape?: (syft_proto.types.syft.v1.IShape|null);
-
-                    /** Arg arg_tensor */
-                    arg_tensor?: (syft_proto.types.torch.v1.ITorchTensor|null);
-
-                    /** Arg arg_torch_param */
-                    arg_torch_param?: (syft_proto.types.torch.v1.IParameter|null);
-
-                    /** Arg arg_pointer_tensor */
-                    arg_pointer_tensor?: (syft_proto.generic.pointers.v1.IPointerTensor|null);
-
-                    /** Arg arg_placeholder */
-                    arg_placeholder?: (syft_proto.execution.v1.IPlaceholder|null);
-
-                    /** Arg arg_placeholder_id */
-                    arg_placeholder_id?: (syft_proto.execution.v1.IPlaceholderId|null);
-                }
-
-                /** Represents an Arg. */
-                class Arg implements IArg {
-
-                    /**
-                     * Constructs a new Arg.
-                     * @param [properties] Properties to set
-                     */
-                    constructor(properties?: syft_proto.types.syft.v1.IArg);
-
-                    /** Arg arg_bool. */
-                    public arg_bool: boolean;
-
-                    /** Arg arg_int. */
-                    public arg_int: number;
-
-                    /** Arg arg_float. */
-                    public arg_float: number;
-
-                    /** Arg arg_string. */
-                    public arg_string: string;
-
-                    /** Arg arg_shape. */
-                    public arg_shape?: (syft_proto.types.syft.v1.IShape|null);
-
-                    /** Arg arg_tensor. */
-                    public arg_tensor?: (syft_proto.types.torch.v1.ITorchTensor|null);
-
-                    /** Arg arg_torch_param. */
-                    public arg_torch_param?: (syft_proto.types.torch.v1.IParameter|null);
-
-                    /** Arg arg_pointer_tensor. */
-                    public arg_pointer_tensor?: (syft_proto.generic.pointers.v1.IPointerTensor|null);
-
-                    /** Arg arg_placeholder. */
-                    public arg_placeholder?: (syft_proto.execution.v1.IPlaceholder|null);
-
-                    /** Arg arg_placeholder_id. */
-                    public arg_placeholder_id?: (syft_proto.execution.v1.IPlaceholderId|null);
-
-                    /** Arg arg. */
-                    public arg?: ("arg_bool"|"arg_int"|"arg_float"|"arg_string"|"arg_shape"|"arg_tensor"|"arg_torch_param"|"arg_pointer_tensor"|"arg_placeholder"|"arg_placeholder_id");
-
-                    /**
-                     * Creates a new Arg instance using the specified properties.
-                     * @param [properties] Properties to set
-                     * @returns Arg instance
-                     */
-                    public static create(properties?: syft_proto.types.syft.v1.IArg): syft_proto.types.syft.v1.Arg;
-
-                    /**
-                     * Encodes the specified Arg message. Does not implicitly {@link syft_proto.types.syft.v1.Arg.verify|verify} messages.
-                     * @param message Arg message or plain object to encode
-                     * @param [writer] Writer to encode to
-                     * @returns Writer
-                     */
-                    public static encode(message: syft_proto.types.syft.v1.IArg, writer?: $protobuf.Writer): $protobuf.Writer;
-
-                    /**
-                     * Encodes the specified Arg message, length delimited. Does not implicitly {@link syft_proto.types.syft.v1.Arg.verify|verify} messages.
-                     * @param message Arg message or plain object to encode
-                     * @param [writer] Writer to encode to
-                     * @returns Writer
-                     */
-                    public static encodeDelimited(message: syft_proto.types.syft.v1.IArg, writer?: $protobuf.Writer): $protobuf.Writer;
-
-                    /**
-                     * Decodes an Arg message from the specified reader or buffer.
-                     * @param reader Reader or buffer to decode from
-                     * @param [length] Message length if known beforehand
-                     * @returns Arg
-                     * @throws {Error} If the payload is not a reader or valid buffer
-                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                     */
-                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): syft_proto.types.syft.v1.Arg;
-
-                    /**
-                     * Decodes an Arg message from the specified reader or buffer, length delimited.
-                     * @param reader Reader or buffer to decode from
-                     * @returns Arg
-                     * @throws {Error} If the payload is not a reader or valid buffer
-                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                     */
-                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): syft_proto.types.syft.v1.Arg;
-
-                    /**
-                     * Verifies an Arg message.
-                     * @param message Plain object to verify
-                     * @returns `null` if valid, otherwise the reason why it is not
-                     */
-                    public static verify(message: { [k: string]: any }): (string|null);
-
-                    /**
-                     * Creates an Arg message from a plain object. Also converts values to their respective internal types.
-                     * @param object Plain object
-                     * @returns Arg
-                     */
-                    public static fromObject(object: { [k: string]: any }): syft_proto.types.syft.v1.Arg;
-
-                    /**
-                     * Creates a plain object from an Arg message. Also converts values to other types if specified.
-                     * @param message Arg
-                     * @param [options] Conversion options
-                     * @returns Plain object
-                     */
-                    public static toObject(message: syft_proto.types.syft.v1.Arg, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-                    /**
-                     * Converts this Arg to JSON.
-                     * @returns JSON object
-                     */
-                    public toJSON(): { [k: string]: any };
-                }
-
                 /** Properties of an Id. */
                 interface IId {
 
@@ -1940,6 +1820,153 @@ export namespace syft_proto {
 
                     /**
                      * Converts this Shape to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                /** Properties of an Arg. */
+                interface IArg {
+
+                    /** Arg arg_bool */
+                    arg_bool?: (boolean|null);
+
+                    /** Arg arg_int */
+                    arg_int?: (number|null);
+
+                    /** Arg arg_float */
+                    arg_float?: (number|null);
+
+                    /** Arg arg_string */
+                    arg_string?: (string|null);
+
+                    /** Arg arg_shape */
+                    arg_shape?: (syft_proto.types.syft.v1.IShape|null);
+
+                    /** Arg arg_tensor */
+                    arg_tensor?: (syft_proto.types.torch.v1.ITorchTensor|null);
+
+                    /** Arg arg_torch_param */
+                    arg_torch_param?: (syft_proto.types.torch.v1.IParameter|null);
+
+                    /** Arg arg_pointer_tensor */
+                    arg_pointer_tensor?: (syft_proto.generic.pointers.v1.IPointerTensor|null);
+
+                    /** Arg arg_placeholder */
+                    arg_placeholder?: (syft_proto.execution.v1.IPlaceholder|null);
+
+                    /** Arg arg_placeholder_id */
+                    arg_placeholder_id?: (syft_proto.execution.v1.IPlaceholderId|null);
+                }
+
+                /** Represents an Arg. */
+                class Arg implements IArg {
+
+                    /**
+                     * Constructs a new Arg.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: syft_proto.types.syft.v1.IArg);
+
+                    /** Arg arg_bool. */
+                    public arg_bool: boolean;
+
+                    /** Arg arg_int. */
+                    public arg_int: number;
+
+                    /** Arg arg_float. */
+                    public arg_float: number;
+
+                    /** Arg arg_string. */
+                    public arg_string: string;
+
+                    /** Arg arg_shape. */
+                    public arg_shape?: (syft_proto.types.syft.v1.IShape|null);
+
+                    /** Arg arg_tensor. */
+                    public arg_tensor?: (syft_proto.types.torch.v1.ITorchTensor|null);
+
+                    /** Arg arg_torch_param. */
+                    public arg_torch_param?: (syft_proto.types.torch.v1.IParameter|null);
+
+                    /** Arg arg_pointer_tensor. */
+                    public arg_pointer_tensor?: (syft_proto.generic.pointers.v1.IPointerTensor|null);
+
+                    /** Arg arg_placeholder. */
+                    public arg_placeholder?: (syft_proto.execution.v1.IPlaceholder|null);
+
+                    /** Arg arg_placeholder_id. */
+                    public arg_placeholder_id?: (syft_proto.execution.v1.IPlaceholderId|null);
+
+                    /** Arg arg. */
+                    public arg?: ("arg_bool"|"arg_int"|"arg_float"|"arg_string"|"arg_shape"|"arg_tensor"|"arg_torch_param"|"arg_pointer_tensor"|"arg_placeholder"|"arg_placeholder_id");
+
+                    /**
+                     * Creates a new Arg instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns Arg instance
+                     */
+                    public static create(properties?: syft_proto.types.syft.v1.IArg): syft_proto.types.syft.v1.Arg;
+
+                    /**
+                     * Encodes the specified Arg message. Does not implicitly {@link syft_proto.types.syft.v1.Arg.verify|verify} messages.
+                     * @param message Arg message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: syft_proto.types.syft.v1.IArg, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified Arg message, length delimited. Does not implicitly {@link syft_proto.types.syft.v1.Arg.verify|verify} messages.
+                     * @param message Arg message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: syft_proto.types.syft.v1.IArg, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes an Arg message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns Arg
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): syft_proto.types.syft.v1.Arg;
+
+                    /**
+                     * Decodes an Arg message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns Arg
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): syft_proto.types.syft.v1.Arg;
+
+                    /**
+                     * Verifies an Arg message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates an Arg message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns Arg
+                     */
+                    public static fromObject(object: { [k: string]: any }): syft_proto.types.syft.v1.Arg;
+
+                    /**
+                     * Creates a plain object from an Arg message. Also converts values to other types if specified.
+                     * @param message Arg
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: syft_proto.types.syft.v1.Arg, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this Arg to JSON.
                      * @returns JSON object
                      */
                     public toJSON(): { [k: string]: any };

--- a/js/protobuf.js
+++ b/js/protobuf.js
@@ -5025,7 +5025,7 @@ $root.syft_proto = (function() {
                      * @property {boolean|null} [arg_bool] Arg arg_bool
                      * @property {number|null} [arg_int] Arg arg_int
                      * @property {number|null} [arg_float] Arg arg_float
-                     * @property {string|null} [arg_string] Arg arg_string
+                     * @property {string|null} [arg_str] Arg arg_str
                      * @property {syft_proto.types.syft.v1.IShape|null} [arg_shape] Arg arg_shape
                      * @property {syft_proto.types.torch.v1.ITorchTensor|null} [arg_tensor] Arg arg_tensor
                      * @property {syft_proto.types.torch.v1.IParameter|null} [arg_torch_param] Arg arg_torch_param
@@ -5074,12 +5074,12 @@ $root.syft_proto = (function() {
                     Arg.prototype.arg_float = 0;
 
                     /**
-                     * Arg arg_string.
-                     * @member {string} arg_string
+                     * Arg arg_str.
+                     * @member {string} arg_str
                      * @memberof syft_proto.types.syft.v1.Arg
                      * @instance
                      */
-                    Arg.prototype.arg_string = "";
+                    Arg.prototype.arg_str = "";
 
                     /**
                      * Arg arg_shape.
@@ -5134,12 +5134,12 @@ $root.syft_proto = (function() {
 
                     /**
                      * Arg arg.
-                     * @member {"arg_bool"|"arg_int"|"arg_float"|"arg_string"|"arg_shape"|"arg_tensor"|"arg_torch_param"|"arg_pointer_tensor"|"arg_placeholder"|"arg_placeholder_id"|undefined} arg
+                     * @member {"arg_bool"|"arg_int"|"arg_float"|"arg_str"|"arg_shape"|"arg_tensor"|"arg_torch_param"|"arg_pointer_tensor"|"arg_placeholder"|"arg_placeholder_id"|undefined} arg
                      * @memberof syft_proto.types.syft.v1.Arg
                      * @instance
                      */
                     Object.defineProperty(Arg.prototype, "arg", {
-                        get: $util.oneOfGetter($oneOfFields = ["arg_bool", "arg_int", "arg_float", "arg_string", "arg_shape", "arg_tensor", "arg_torch_param", "arg_pointer_tensor", "arg_placeholder", "arg_placeholder_id"]),
+                        get: $util.oneOfGetter($oneOfFields = ["arg_bool", "arg_int", "arg_float", "arg_str", "arg_shape", "arg_tensor", "arg_torch_param", "arg_pointer_tensor", "arg_placeholder", "arg_placeholder_id"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
 
@@ -5173,8 +5173,8 @@ $root.syft_proto = (function() {
                             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.arg_int);
                         if (message.arg_float != null && message.hasOwnProperty("arg_float"))
                             writer.uint32(/* id 3, wireType 5 =*/29).float(message.arg_float);
-                        if (message.arg_string != null && message.hasOwnProperty("arg_string"))
-                            writer.uint32(/* id 4, wireType 2 =*/34).string(message.arg_string);
+                        if (message.arg_str != null && message.hasOwnProperty("arg_str"))
+                            writer.uint32(/* id 4, wireType 2 =*/34).string(message.arg_str);
                         if (message.arg_shape != null && message.hasOwnProperty("arg_shape"))
                             $root.syft_proto.types.syft.v1.Shape.encode(message.arg_shape, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
                         if (message.arg_tensor != null && message.hasOwnProperty("arg_tensor"))
@@ -5231,7 +5231,7 @@ $root.syft_proto = (function() {
                                 message.arg_float = reader.float();
                                 break;
                             case 4:
-                                message.arg_string = reader.string();
+                                message.arg_str = reader.string();
                                 break;
                             case 5:
                                 message.arg_shape = $root.syft_proto.types.syft.v1.Shape.decode(reader, reader.uint32());
@@ -5306,12 +5306,12 @@ $root.syft_proto = (function() {
                             if (typeof message.arg_float !== "number")
                                 return "arg_float: number expected";
                         }
-                        if (message.arg_string != null && message.hasOwnProperty("arg_string")) {
+                        if (message.arg_str != null && message.hasOwnProperty("arg_str")) {
                             if (properties.arg === 1)
                                 return "arg: multiple values";
                             properties.arg = 1;
-                            if (!$util.isString(message.arg_string))
-                                return "arg_string: string expected";
+                            if (!$util.isString(message.arg_str))
+                                return "arg_str: string expected";
                         }
                         if (message.arg_shape != null && message.hasOwnProperty("arg_shape")) {
                             if (properties.arg === 1)
@@ -5394,8 +5394,8 @@ $root.syft_proto = (function() {
                             message.arg_int = object.arg_int | 0;
                         if (object.arg_float != null)
                             message.arg_float = Number(object.arg_float);
-                        if (object.arg_string != null)
-                            message.arg_string = String(object.arg_string);
+                        if (object.arg_str != null)
+                            message.arg_str = String(object.arg_str);
                         if (object.arg_shape != null) {
                             if (typeof object.arg_shape !== "object")
                                 throw TypeError(".syft_proto.types.syft.v1.Arg.arg_shape: object expected");
@@ -5457,10 +5457,10 @@ $root.syft_proto = (function() {
                             if (options.oneofs)
                                 object.arg = "arg_float";
                         }
-                        if (message.arg_string != null && message.hasOwnProperty("arg_string")) {
-                            object.arg_string = message.arg_string;
+                        if (message.arg_str != null && message.hasOwnProperty("arg_str")) {
+                            object.arg_str = message.arg_str;
                             if (options.oneofs)
-                                object.arg = "arg_string";
+                                object.arg = "arg_str";
                         }
                         if (message.arg_shape != null && message.hasOwnProperty("arg_shape")) {
                             object.arg_shape = $root.syft_proto.types.syft.v1.Shape.toObject(message.arg_shape, options);

--- a/js/protobuf.js
+++ b/js/protobuf.js
@@ -42,11 +42,15 @@ $root.syft_proto = (function() {
                  * Properties of a CommunicationAction.
                  * @memberof syft_proto.execution.v1
                  * @interface ICommunicationAction
-                 * @property {string|null} [name] CommunicationAction name
-                 * @property {syft_proto.types.syft.v1.IId|null} [obj_id] CommunicationAction obj_id
-                 * @property {syft_proto.types.syft.v1.IId|null} [source] CommunicationAction source
-                 * @property {Array.<syft_proto.types.syft.v1.IId>|null} [destinations] CommunicationAction destinations
+                 * @property {string|null} [command] CommunicationAction command
+                 * @property {syft_proto.types.syft.v1.IId|null} [target_id] CommunicationAction target_id
+                 * @property {syft_proto.generic.pointers.v1.IPointerTensor|null} [target_pointer] CommunicationAction target_pointer
+                 * @property {syft_proto.execution.v1.IPlaceholderId|null} [target_placeholder_id] CommunicationAction target_placeholder_id
+                 * @property {syft_proto.types.torch.v1.ITorchTensor|null} [target_tensor] CommunicationAction target_tensor
+                 * @property {Array.<syft_proto.types.syft.v1.IArg>|null} [args] CommunicationAction args
                  * @property {Object.<string,syft_proto.types.syft.v1.IArg>|null} [kwargs] CommunicationAction kwargs
+                 * @property {Array.<syft_proto.types.syft.v1.IId>|null} [return_ids] CommunicationAction return_ids
+                 * @property {Array.<syft_proto.execution.v1.IPlaceholderId>|null} [return_placeholder_ids] CommunicationAction return_placeholder_ids
                  */
 
                 /**
@@ -58,8 +62,10 @@ $root.syft_proto = (function() {
                  * @param {syft_proto.execution.v1.ICommunicationAction=} [properties] Properties to set
                  */
                 function CommunicationAction(properties) {
-                    this.destinations = [];
+                    this.args = [];
                     this.kwargs = {};
+                    this.return_ids = [];
+                    this.return_placeholder_ids = [];
                     if (properties)
                         for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                             if (properties[keys[i]] != null)
@@ -67,36 +73,52 @@ $root.syft_proto = (function() {
                 }
 
                 /**
-                 * CommunicationAction name.
-                 * @member {string} name
+                 * CommunicationAction command.
+                 * @member {string} command
                  * @memberof syft_proto.execution.v1.CommunicationAction
                  * @instance
                  */
-                CommunicationAction.prototype.name = "";
+                CommunicationAction.prototype.command = "";
 
                 /**
-                 * CommunicationAction obj_id.
-                 * @member {syft_proto.types.syft.v1.IId|null|undefined} obj_id
+                 * CommunicationAction target_id.
+                 * @member {syft_proto.types.syft.v1.IId|null|undefined} target_id
                  * @memberof syft_proto.execution.v1.CommunicationAction
                  * @instance
                  */
-                CommunicationAction.prototype.obj_id = null;
+                CommunicationAction.prototype.target_id = null;
 
                 /**
-                 * CommunicationAction source.
-                 * @member {syft_proto.types.syft.v1.IId|null|undefined} source
+                 * CommunicationAction target_pointer.
+                 * @member {syft_proto.generic.pointers.v1.IPointerTensor|null|undefined} target_pointer
                  * @memberof syft_proto.execution.v1.CommunicationAction
                  * @instance
                  */
-                CommunicationAction.prototype.source = null;
+                CommunicationAction.prototype.target_pointer = null;
 
                 /**
-                 * CommunicationAction destinations.
-                 * @member {Array.<syft_proto.types.syft.v1.IId>} destinations
+                 * CommunicationAction target_placeholder_id.
+                 * @member {syft_proto.execution.v1.IPlaceholderId|null|undefined} target_placeholder_id
                  * @memberof syft_proto.execution.v1.CommunicationAction
                  * @instance
                  */
-                CommunicationAction.prototype.destinations = $util.emptyArray;
+                CommunicationAction.prototype.target_placeholder_id = null;
+
+                /**
+                 * CommunicationAction target_tensor.
+                 * @member {syft_proto.types.torch.v1.ITorchTensor|null|undefined} target_tensor
+                 * @memberof syft_proto.execution.v1.CommunicationAction
+                 * @instance
+                 */
+                CommunicationAction.prototype.target_tensor = null;
+
+                /**
+                 * CommunicationAction args.
+                 * @member {Array.<syft_proto.types.syft.v1.IArg>} args
+                 * @memberof syft_proto.execution.v1.CommunicationAction
+                 * @instance
+                 */
+                CommunicationAction.prototype.args = $util.emptyArray;
 
                 /**
                  * CommunicationAction kwargs.
@@ -105,6 +127,36 @@ $root.syft_proto = (function() {
                  * @instance
                  */
                 CommunicationAction.prototype.kwargs = $util.emptyObject;
+
+                /**
+                 * CommunicationAction return_ids.
+                 * @member {Array.<syft_proto.types.syft.v1.IId>} return_ids
+                 * @memberof syft_proto.execution.v1.CommunicationAction
+                 * @instance
+                 */
+                CommunicationAction.prototype.return_ids = $util.emptyArray;
+
+                /**
+                 * CommunicationAction return_placeholder_ids.
+                 * @member {Array.<syft_proto.execution.v1.IPlaceholderId>} return_placeholder_ids
+                 * @memberof syft_proto.execution.v1.CommunicationAction
+                 * @instance
+                 */
+                CommunicationAction.prototype.return_placeholder_ids = $util.emptyArray;
+
+                // OneOf field names bound to virtual getters and setters
+                var $oneOfFields;
+
+                /**
+                 * CommunicationAction target.
+                 * @member {"target_id"|"target_pointer"|"target_placeholder_id"|"target_tensor"|undefined} target
+                 * @memberof syft_proto.execution.v1.CommunicationAction
+                 * @instance
+                 */
+                Object.defineProperty(CommunicationAction.prototype, "target", {
+                    get: $util.oneOfGetter($oneOfFields = ["target_id", "target_pointer", "target_placeholder_id", "target_tensor"]),
+                    set: $util.oneOfSetter($oneOfFields)
+                });
 
                 /**
                  * Creates a new CommunicationAction instance using the specified properties.
@@ -130,20 +182,30 @@ $root.syft_proto = (function() {
                 CommunicationAction.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && message.hasOwnProperty("name"))
-                        writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                    if (message.obj_id != null && message.hasOwnProperty("obj_id"))
-                        $root.syft_proto.types.syft.v1.Id.encode(message.obj_id, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                    if (message.source != null && message.hasOwnProperty("source"))
-                        $root.syft_proto.types.syft.v1.Id.encode(message.source, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                    if (message.destinations != null && message.destinations.length)
-                        for (var i = 0; i < message.destinations.length; ++i)
-                            $root.syft_proto.types.syft.v1.Id.encode(message.destinations[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                    if (message.command != null && message.hasOwnProperty("command"))
+                        writer.uint32(/* id 1, wireType 2 =*/10).string(message.command);
+                    if (message.target_pointer != null && message.hasOwnProperty("target_pointer"))
+                        $root.syft_proto.generic.pointers.v1.PointerTensor.encode(message.target_pointer, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                    if (message.target_placeholder_id != null && message.hasOwnProperty("target_placeholder_id"))
+                        $root.syft_proto.execution.v1.PlaceholderId.encode(message.target_placeholder_id, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                    if (message.target_tensor != null && message.hasOwnProperty("target_tensor"))
+                        $root.syft_proto.types.torch.v1.TorchTensor.encode(message.target_tensor, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                    if (message.args != null && message.args.length)
+                        for (var i = 0; i < message.args.length; ++i)
+                            $root.syft_proto.types.syft.v1.Arg.encode(message.args[i], writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
                     if (message.kwargs != null && message.hasOwnProperty("kwargs"))
                         for (var keys = Object.keys(message.kwargs), i = 0; i < keys.length; ++i) {
-                            writer.uint32(/* id 5, wireType 2 =*/42).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
+                            writer.uint32(/* id 6, wireType 2 =*/50).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
                             $root.syft_proto.types.syft.v1.Arg.encode(message.kwargs[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim().ldelim();
                         }
+                    if (message.return_ids != null && message.return_ids.length)
+                        for (var i = 0; i < message.return_ids.length; ++i)
+                            $root.syft_proto.types.syft.v1.Id.encode(message.return_ids[i], writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                    if (message.return_placeholder_ids != null && message.return_placeholder_ids.length)
+                        for (var i = 0; i < message.return_placeholder_ids.length; ++i)
+                            $root.syft_proto.execution.v1.PlaceholderId.encode(message.return_placeholder_ids[i], writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                    if (message.target_id != null && message.hasOwnProperty("target_id"))
+                        $root.syft_proto.types.syft.v1.Id.encode(message.target_id, writer.uint32(/* id 9, wireType 2 =*/74).fork()).ldelim();
                     return writer;
                 };
 
@@ -179,26 +241,42 @@ $root.syft_proto = (function() {
                         var tag = reader.uint32();
                         switch (tag >>> 3) {
                         case 1:
-                            message.name = reader.string();
+                            message.command = reader.string();
+                            break;
+                        case 9:
+                            message.target_id = $root.syft_proto.types.syft.v1.Id.decode(reader, reader.uint32());
                             break;
                         case 2:
-                            message.obj_id = $root.syft_proto.types.syft.v1.Id.decode(reader, reader.uint32());
+                            message.target_pointer = $root.syft_proto.generic.pointers.v1.PointerTensor.decode(reader, reader.uint32());
                             break;
                         case 3:
-                            message.source = $root.syft_proto.types.syft.v1.Id.decode(reader, reader.uint32());
+                            message.target_placeholder_id = $root.syft_proto.execution.v1.PlaceholderId.decode(reader, reader.uint32());
                             break;
                         case 4:
-                            if (!(message.destinations && message.destinations.length))
-                                message.destinations = [];
-                            message.destinations.push($root.syft_proto.types.syft.v1.Id.decode(reader, reader.uint32()));
+                            message.target_tensor = $root.syft_proto.types.torch.v1.TorchTensor.decode(reader, reader.uint32());
                             break;
                         case 5:
+                            if (!(message.args && message.args.length))
+                                message.args = [];
+                            message.args.push($root.syft_proto.types.syft.v1.Arg.decode(reader, reader.uint32()));
+                            break;
+                        case 6:
                             reader.skip().pos++;
                             if (message.kwargs === $util.emptyObject)
                                 message.kwargs = {};
                             key = reader.string();
                             reader.pos++;
                             message.kwargs[key] = $root.syft_proto.types.syft.v1.Arg.decode(reader, reader.uint32());
+                            break;
+                        case 7:
+                            if (!(message.return_ids && message.return_ids.length))
+                                message.return_ids = [];
+                            message.return_ids.push($root.syft_proto.types.syft.v1.Id.decode(reader, reader.uint32()));
+                            break;
+                        case 8:
+                            if (!(message.return_placeholder_ids && message.return_placeholder_ids.length))
+                                message.return_placeholder_ids = [];
+                            message.return_placeholder_ids.push($root.syft_proto.execution.v1.PlaceholderId.decode(reader, reader.uint32()));
                             break;
                         default:
                             reader.skipType(tag & 7);
@@ -235,26 +313,55 @@ $root.syft_proto = (function() {
                 CommunicationAction.verify = function verify(message) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
-                    if (message.name != null && message.hasOwnProperty("name"))
-                        if (!$util.isString(message.name))
-                            return "name: string expected";
-                    if (message.obj_id != null && message.hasOwnProperty("obj_id")) {
-                        var error = $root.syft_proto.types.syft.v1.Id.verify(message.obj_id);
-                        if (error)
-                            return "obj_id." + error;
-                    }
-                    if (message.source != null && message.hasOwnProperty("source")) {
-                        var error = $root.syft_proto.types.syft.v1.Id.verify(message.source);
-                        if (error)
-                            return "source." + error;
-                    }
-                    if (message.destinations != null && message.hasOwnProperty("destinations")) {
-                        if (!Array.isArray(message.destinations))
-                            return "destinations: array expected";
-                        for (var i = 0; i < message.destinations.length; ++i) {
-                            var error = $root.syft_proto.types.syft.v1.Id.verify(message.destinations[i]);
+                    var properties = {};
+                    if (message.command != null && message.hasOwnProperty("command"))
+                        if (!$util.isString(message.command))
+                            return "command: string expected";
+                    if (message.target_id != null && message.hasOwnProperty("target_id")) {
+                        properties.target = 1;
+                        {
+                            var error = $root.syft_proto.types.syft.v1.Id.verify(message.target_id);
                             if (error)
-                                return "destinations." + error;
+                                return "target_id." + error;
+                        }
+                    }
+                    if (message.target_pointer != null && message.hasOwnProperty("target_pointer")) {
+                        if (properties.target === 1)
+                            return "target: multiple values";
+                        properties.target = 1;
+                        {
+                            var error = $root.syft_proto.generic.pointers.v1.PointerTensor.verify(message.target_pointer);
+                            if (error)
+                                return "target_pointer." + error;
+                        }
+                    }
+                    if (message.target_placeholder_id != null && message.hasOwnProperty("target_placeholder_id")) {
+                        if (properties.target === 1)
+                            return "target: multiple values";
+                        properties.target = 1;
+                        {
+                            var error = $root.syft_proto.execution.v1.PlaceholderId.verify(message.target_placeholder_id);
+                            if (error)
+                                return "target_placeholder_id." + error;
+                        }
+                    }
+                    if (message.target_tensor != null && message.hasOwnProperty("target_tensor")) {
+                        if (properties.target === 1)
+                            return "target: multiple values";
+                        properties.target = 1;
+                        {
+                            var error = $root.syft_proto.types.torch.v1.TorchTensor.verify(message.target_tensor);
+                            if (error)
+                                return "target_tensor." + error;
+                        }
+                    }
+                    if (message.args != null && message.hasOwnProperty("args")) {
+                        if (!Array.isArray(message.args))
+                            return "args: array expected";
+                        for (var i = 0; i < message.args.length; ++i) {
+                            var error = $root.syft_proto.types.syft.v1.Arg.verify(message.args[i]);
+                            if (error)
+                                return "args." + error;
                         }
                     }
                     if (message.kwargs != null && message.hasOwnProperty("kwargs")) {
@@ -265,6 +372,24 @@ $root.syft_proto = (function() {
                             var error = $root.syft_proto.types.syft.v1.Arg.verify(message.kwargs[key[i]]);
                             if (error)
                                 return "kwargs." + error;
+                        }
+                    }
+                    if (message.return_ids != null && message.hasOwnProperty("return_ids")) {
+                        if (!Array.isArray(message.return_ids))
+                            return "return_ids: array expected";
+                        for (var i = 0; i < message.return_ids.length; ++i) {
+                            var error = $root.syft_proto.types.syft.v1.Id.verify(message.return_ids[i]);
+                            if (error)
+                                return "return_ids." + error;
+                        }
+                    }
+                    if (message.return_placeholder_ids != null && message.hasOwnProperty("return_placeholder_ids")) {
+                        if (!Array.isArray(message.return_placeholder_ids))
+                            return "return_placeholder_ids: array expected";
+                        for (var i = 0; i < message.return_placeholder_ids.length; ++i) {
+                            var error = $root.syft_proto.execution.v1.PlaceholderId.verify(message.return_placeholder_ids[i]);
+                            if (error)
+                                return "return_placeholder_ids." + error;
                         }
                     }
                     return null;
@@ -282,26 +407,36 @@ $root.syft_proto = (function() {
                     if (object instanceof $root.syft_proto.execution.v1.CommunicationAction)
                         return object;
                     var message = new $root.syft_proto.execution.v1.CommunicationAction();
-                    if (object.name != null)
-                        message.name = String(object.name);
-                    if (object.obj_id != null) {
-                        if (typeof object.obj_id !== "object")
-                            throw TypeError(".syft_proto.execution.v1.CommunicationAction.obj_id: object expected");
-                        message.obj_id = $root.syft_proto.types.syft.v1.Id.fromObject(object.obj_id);
+                    if (object.command != null)
+                        message.command = String(object.command);
+                    if (object.target_id != null) {
+                        if (typeof object.target_id !== "object")
+                            throw TypeError(".syft_proto.execution.v1.CommunicationAction.target_id: object expected");
+                        message.target_id = $root.syft_proto.types.syft.v1.Id.fromObject(object.target_id);
                     }
-                    if (object.source != null) {
-                        if (typeof object.source !== "object")
-                            throw TypeError(".syft_proto.execution.v1.CommunicationAction.source: object expected");
-                        message.source = $root.syft_proto.types.syft.v1.Id.fromObject(object.source);
+                    if (object.target_pointer != null) {
+                        if (typeof object.target_pointer !== "object")
+                            throw TypeError(".syft_proto.execution.v1.CommunicationAction.target_pointer: object expected");
+                        message.target_pointer = $root.syft_proto.generic.pointers.v1.PointerTensor.fromObject(object.target_pointer);
                     }
-                    if (object.destinations) {
-                        if (!Array.isArray(object.destinations))
-                            throw TypeError(".syft_proto.execution.v1.CommunicationAction.destinations: array expected");
-                        message.destinations = [];
-                        for (var i = 0; i < object.destinations.length; ++i) {
-                            if (typeof object.destinations[i] !== "object")
-                                throw TypeError(".syft_proto.execution.v1.CommunicationAction.destinations: object expected");
-                            message.destinations[i] = $root.syft_proto.types.syft.v1.Id.fromObject(object.destinations[i]);
+                    if (object.target_placeholder_id != null) {
+                        if (typeof object.target_placeholder_id !== "object")
+                            throw TypeError(".syft_proto.execution.v1.CommunicationAction.target_placeholder_id: object expected");
+                        message.target_placeholder_id = $root.syft_proto.execution.v1.PlaceholderId.fromObject(object.target_placeholder_id);
+                    }
+                    if (object.target_tensor != null) {
+                        if (typeof object.target_tensor !== "object")
+                            throw TypeError(".syft_proto.execution.v1.CommunicationAction.target_tensor: object expected");
+                        message.target_tensor = $root.syft_proto.types.torch.v1.TorchTensor.fromObject(object.target_tensor);
+                    }
+                    if (object.args) {
+                        if (!Array.isArray(object.args))
+                            throw TypeError(".syft_proto.execution.v1.CommunicationAction.args: array expected");
+                        message.args = [];
+                        for (var i = 0; i < object.args.length; ++i) {
+                            if (typeof object.args[i] !== "object")
+                                throw TypeError(".syft_proto.execution.v1.CommunicationAction.args: object expected");
+                            message.args[i] = $root.syft_proto.types.syft.v1.Arg.fromObject(object.args[i]);
                         }
                     }
                     if (object.kwargs) {
@@ -312,6 +447,26 @@ $root.syft_proto = (function() {
                             if (typeof object.kwargs[keys[i]] !== "object")
                                 throw TypeError(".syft_proto.execution.v1.CommunicationAction.kwargs: object expected");
                             message.kwargs[keys[i]] = $root.syft_proto.types.syft.v1.Arg.fromObject(object.kwargs[keys[i]]);
+                        }
+                    }
+                    if (object.return_ids) {
+                        if (!Array.isArray(object.return_ids))
+                            throw TypeError(".syft_proto.execution.v1.CommunicationAction.return_ids: array expected");
+                        message.return_ids = [];
+                        for (var i = 0; i < object.return_ids.length; ++i) {
+                            if (typeof object.return_ids[i] !== "object")
+                                throw TypeError(".syft_proto.execution.v1.CommunicationAction.return_ids: object expected");
+                            message.return_ids[i] = $root.syft_proto.types.syft.v1.Id.fromObject(object.return_ids[i]);
+                        }
+                    }
+                    if (object.return_placeholder_ids) {
+                        if (!Array.isArray(object.return_placeholder_ids))
+                            throw TypeError(".syft_proto.execution.v1.CommunicationAction.return_placeholder_ids: array expected");
+                        message.return_placeholder_ids = [];
+                        for (var i = 0; i < object.return_placeholder_ids.length; ++i) {
+                            if (typeof object.return_placeholder_ids[i] !== "object")
+                                throw TypeError(".syft_proto.execution.v1.CommunicationAction.return_placeholder_ids: object expected");
+                            message.return_placeholder_ids[i] = $root.syft_proto.execution.v1.PlaceholderId.fromObject(object.return_placeholder_ids[i]);
                         }
                     }
                     return message;
@@ -330,31 +485,57 @@ $root.syft_proto = (function() {
                     if (!options)
                         options = {};
                     var object = {};
-                    if (options.arrays || options.defaults)
-                        object.destinations = [];
+                    if (options.arrays || options.defaults) {
+                        object.args = [];
+                        object.return_ids = [];
+                        object.return_placeholder_ids = [];
+                    }
                     if (options.objects || options.defaults)
                         object.kwargs = {};
-                    if (options.defaults) {
-                        object.name = "";
-                        object.obj_id = null;
-                        object.source = null;
+                    if (options.defaults)
+                        object.command = "";
+                    if (message.command != null && message.hasOwnProperty("command"))
+                        object.command = message.command;
+                    if (message.target_pointer != null && message.hasOwnProperty("target_pointer")) {
+                        object.target_pointer = $root.syft_proto.generic.pointers.v1.PointerTensor.toObject(message.target_pointer, options);
+                        if (options.oneofs)
+                            object.target = "target_pointer";
                     }
-                    if (message.name != null && message.hasOwnProperty("name"))
-                        object.name = message.name;
-                    if (message.obj_id != null && message.hasOwnProperty("obj_id"))
-                        object.obj_id = $root.syft_proto.types.syft.v1.Id.toObject(message.obj_id, options);
-                    if (message.source != null && message.hasOwnProperty("source"))
-                        object.source = $root.syft_proto.types.syft.v1.Id.toObject(message.source, options);
-                    if (message.destinations && message.destinations.length) {
-                        object.destinations = [];
-                        for (var j = 0; j < message.destinations.length; ++j)
-                            object.destinations[j] = $root.syft_proto.types.syft.v1.Id.toObject(message.destinations[j], options);
+                    if (message.target_placeholder_id != null && message.hasOwnProperty("target_placeholder_id")) {
+                        object.target_placeholder_id = $root.syft_proto.execution.v1.PlaceholderId.toObject(message.target_placeholder_id, options);
+                        if (options.oneofs)
+                            object.target = "target_placeholder_id";
+                    }
+                    if (message.target_tensor != null && message.hasOwnProperty("target_tensor")) {
+                        object.target_tensor = $root.syft_proto.types.torch.v1.TorchTensor.toObject(message.target_tensor, options);
+                        if (options.oneofs)
+                            object.target = "target_tensor";
+                    }
+                    if (message.args && message.args.length) {
+                        object.args = [];
+                        for (var j = 0; j < message.args.length; ++j)
+                            object.args[j] = $root.syft_proto.types.syft.v1.Arg.toObject(message.args[j], options);
                     }
                     var keys2;
                     if (message.kwargs && (keys2 = Object.keys(message.kwargs)).length) {
                         object.kwargs = {};
                         for (var j = 0; j < keys2.length; ++j)
                             object.kwargs[keys2[j]] = $root.syft_proto.types.syft.v1.Arg.toObject(message.kwargs[keys2[j]], options);
+                    }
+                    if (message.return_ids && message.return_ids.length) {
+                        object.return_ids = [];
+                        for (var j = 0; j < message.return_ids.length; ++j)
+                            object.return_ids[j] = $root.syft_proto.types.syft.v1.Id.toObject(message.return_ids[j], options);
+                    }
+                    if (message.return_placeholder_ids && message.return_placeholder_ids.length) {
+                        object.return_placeholder_ids = [];
+                        for (var j = 0; j < message.return_placeholder_ids.length; ++j)
+                            object.return_placeholder_ids[j] = $root.syft_proto.execution.v1.PlaceholderId.toObject(message.return_placeholder_ids[j], options);
+                    }
+                    if (message.target_id != null && message.hasOwnProperty("target_id")) {
+                        object.target_id = $root.syft_proto.types.syft.v1.Id.toObject(message.target_id, options);
+                        if (options.oneofs)
+                            object.target = "target_id";
                     }
                     return object;
                 };
@@ -371,6 +552,198 @@ $root.syft_proto = (function() {
                 };
 
                 return CommunicationAction;
+            })();
+
+            v1.PlaceholderId = (function() {
+
+                /**
+                 * Properties of a PlaceholderId.
+                 * @memberof syft_proto.execution.v1
+                 * @interface IPlaceholderId
+                 * @property {syft_proto.types.syft.v1.IId|null} [id] PlaceholderId id
+                 */
+
+                /**
+                 * Constructs a new PlaceholderId.
+                 * @memberof syft_proto.execution.v1
+                 * @classdesc Represents a PlaceholderId.
+                 * @implements IPlaceholderId
+                 * @constructor
+                 * @param {syft_proto.execution.v1.IPlaceholderId=} [properties] Properties to set
+                 */
+                function PlaceholderId(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * PlaceholderId id.
+                 * @member {syft_proto.types.syft.v1.IId|null|undefined} id
+                 * @memberof syft_proto.execution.v1.PlaceholderId
+                 * @instance
+                 */
+                PlaceholderId.prototype.id = null;
+
+                /**
+                 * Creates a new PlaceholderId instance using the specified properties.
+                 * @function create
+                 * @memberof syft_proto.execution.v1.PlaceholderId
+                 * @static
+                 * @param {syft_proto.execution.v1.IPlaceholderId=} [properties] Properties to set
+                 * @returns {syft_proto.execution.v1.PlaceholderId} PlaceholderId instance
+                 */
+                PlaceholderId.create = function create(properties) {
+                    return new PlaceholderId(properties);
+                };
+
+                /**
+                 * Encodes the specified PlaceholderId message. Does not implicitly {@link syft_proto.execution.v1.PlaceholderId.verify|verify} messages.
+                 * @function encode
+                 * @memberof syft_proto.execution.v1.PlaceholderId
+                 * @static
+                 * @param {syft_proto.execution.v1.IPlaceholderId} message PlaceholderId message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                PlaceholderId.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    if (message.id != null && message.hasOwnProperty("id"))
+                        $root.syft_proto.types.syft.v1.Id.encode(message.id, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified PlaceholderId message, length delimited. Does not implicitly {@link syft_proto.execution.v1.PlaceholderId.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof syft_proto.execution.v1.PlaceholderId
+                 * @static
+                 * @param {syft_proto.execution.v1.IPlaceholderId} message PlaceholderId message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                PlaceholderId.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes a PlaceholderId message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof syft_proto.execution.v1.PlaceholderId
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {syft_proto.execution.v1.PlaceholderId} PlaceholderId
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                PlaceholderId.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.syft_proto.execution.v1.PlaceholderId();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        case 1:
+                            message.id = $root.syft_proto.types.syft.v1.Id.decode(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+
+                /**
+                 * Decodes a PlaceholderId message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof syft_proto.execution.v1.PlaceholderId
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {syft_proto.execution.v1.PlaceholderId} PlaceholderId
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                PlaceholderId.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies a PlaceholderId message.
+                 * @function verify
+                 * @memberof syft_proto.execution.v1.PlaceholderId
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                PlaceholderId.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (message.id != null && message.hasOwnProperty("id")) {
+                        var error = $root.syft_proto.types.syft.v1.Id.verify(message.id);
+                        if (error)
+                            return "id." + error;
+                    }
+                    return null;
+                };
+
+                /**
+                 * Creates a PlaceholderId message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof syft_proto.execution.v1.PlaceholderId
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {syft_proto.execution.v1.PlaceholderId} PlaceholderId
+                 */
+                PlaceholderId.fromObject = function fromObject(object) {
+                    if (object instanceof $root.syft_proto.execution.v1.PlaceholderId)
+                        return object;
+                    var message = new $root.syft_proto.execution.v1.PlaceholderId();
+                    if (object.id != null) {
+                        if (typeof object.id !== "object")
+                            throw TypeError(".syft_proto.execution.v1.PlaceholderId.id: object expected");
+                        message.id = $root.syft_proto.types.syft.v1.Id.fromObject(object.id);
+                    }
+                    return message;
+                };
+
+                /**
+                 * Creates a plain object from a PlaceholderId message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof syft_proto.execution.v1.PlaceholderId
+                 * @static
+                 * @param {syft_proto.execution.v1.PlaceholderId} message PlaceholderId
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                PlaceholderId.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    var object = {};
+                    if (options.defaults)
+                        object.id = null;
+                    if (message.id != null && message.hasOwnProperty("id"))
+                        object.id = $root.syft_proto.types.syft.v1.Id.toObject(message.id, options);
+                    return object;
+                };
+
+                /**
+                 * Converts this PlaceholderId to JSON.
+                 * @function toJSON
+                 * @memberof syft_proto.execution.v1.PlaceholderId
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                PlaceholderId.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                return PlaceholderId;
             })();
 
             v1.Placeholder = (function() {
@@ -652,198 +1025,6 @@ $root.syft_proto = (function() {
                 };
 
                 return Placeholder;
-            })();
-
-            v1.PlaceholderId = (function() {
-
-                /**
-                 * Properties of a PlaceholderId.
-                 * @memberof syft_proto.execution.v1
-                 * @interface IPlaceholderId
-                 * @property {syft_proto.types.syft.v1.IId|null} [id] PlaceholderId id
-                 */
-
-                /**
-                 * Constructs a new PlaceholderId.
-                 * @memberof syft_proto.execution.v1
-                 * @classdesc Represents a PlaceholderId.
-                 * @implements IPlaceholderId
-                 * @constructor
-                 * @param {syft_proto.execution.v1.IPlaceholderId=} [properties] Properties to set
-                 */
-                function PlaceholderId(properties) {
-                    if (properties)
-                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
-                                this[keys[i]] = properties[keys[i]];
-                }
-
-                /**
-                 * PlaceholderId id.
-                 * @member {syft_proto.types.syft.v1.IId|null|undefined} id
-                 * @memberof syft_proto.execution.v1.PlaceholderId
-                 * @instance
-                 */
-                PlaceholderId.prototype.id = null;
-
-                /**
-                 * Creates a new PlaceholderId instance using the specified properties.
-                 * @function create
-                 * @memberof syft_proto.execution.v1.PlaceholderId
-                 * @static
-                 * @param {syft_proto.execution.v1.IPlaceholderId=} [properties] Properties to set
-                 * @returns {syft_proto.execution.v1.PlaceholderId} PlaceholderId instance
-                 */
-                PlaceholderId.create = function create(properties) {
-                    return new PlaceholderId(properties);
-                };
-
-                /**
-                 * Encodes the specified PlaceholderId message. Does not implicitly {@link syft_proto.execution.v1.PlaceholderId.verify|verify} messages.
-                 * @function encode
-                 * @memberof syft_proto.execution.v1.PlaceholderId
-                 * @static
-                 * @param {syft_proto.execution.v1.IPlaceholderId} message PlaceholderId message or plain object to encode
-                 * @param {$protobuf.Writer} [writer] Writer to encode to
-                 * @returns {$protobuf.Writer} Writer
-                 */
-                PlaceholderId.encode = function encode(message, writer) {
-                    if (!writer)
-                        writer = $Writer.create();
-                    if (message.id != null && message.hasOwnProperty("id"))
-                        $root.syft_proto.types.syft.v1.Id.encode(message.id, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                    return writer;
-                };
-
-                /**
-                 * Encodes the specified PlaceholderId message, length delimited. Does not implicitly {@link syft_proto.execution.v1.PlaceholderId.verify|verify} messages.
-                 * @function encodeDelimited
-                 * @memberof syft_proto.execution.v1.PlaceholderId
-                 * @static
-                 * @param {syft_proto.execution.v1.IPlaceholderId} message PlaceholderId message or plain object to encode
-                 * @param {$protobuf.Writer} [writer] Writer to encode to
-                 * @returns {$protobuf.Writer} Writer
-                 */
-                PlaceholderId.encodeDelimited = function encodeDelimited(message, writer) {
-                    return this.encode(message, writer).ldelim();
-                };
-
-                /**
-                 * Decodes a PlaceholderId message from the specified reader or buffer.
-                 * @function decode
-                 * @memberof syft_proto.execution.v1.PlaceholderId
-                 * @static
-                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                 * @param {number} [length] Message length if known beforehand
-                 * @returns {syft_proto.execution.v1.PlaceholderId} PlaceholderId
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                PlaceholderId.decode = function decode(reader, length) {
-                    if (!(reader instanceof $Reader))
-                        reader = $Reader.create(reader);
-                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.syft_proto.execution.v1.PlaceholderId();
-                    while (reader.pos < end) {
-                        var tag = reader.uint32();
-                        switch (tag >>> 3) {
-                        case 1:
-                            message.id = $root.syft_proto.types.syft.v1.Id.decode(reader, reader.uint32());
-                            break;
-                        default:
-                            reader.skipType(tag & 7);
-                            break;
-                        }
-                    }
-                    return message;
-                };
-
-                /**
-                 * Decodes a PlaceholderId message from the specified reader or buffer, length delimited.
-                 * @function decodeDelimited
-                 * @memberof syft_proto.execution.v1.PlaceholderId
-                 * @static
-                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                 * @returns {syft_proto.execution.v1.PlaceholderId} PlaceholderId
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                PlaceholderId.decodeDelimited = function decodeDelimited(reader) {
-                    if (!(reader instanceof $Reader))
-                        reader = new $Reader(reader);
-                    return this.decode(reader, reader.uint32());
-                };
-
-                /**
-                 * Verifies a PlaceholderId message.
-                 * @function verify
-                 * @memberof syft_proto.execution.v1.PlaceholderId
-                 * @static
-                 * @param {Object.<string,*>} message Plain object to verify
-                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
-                 */
-                PlaceholderId.verify = function verify(message) {
-                    if (typeof message !== "object" || message === null)
-                        return "object expected";
-                    if (message.id != null && message.hasOwnProperty("id")) {
-                        var error = $root.syft_proto.types.syft.v1.Id.verify(message.id);
-                        if (error)
-                            return "id." + error;
-                    }
-                    return null;
-                };
-
-                /**
-                 * Creates a PlaceholderId message from a plain object. Also converts values to their respective internal types.
-                 * @function fromObject
-                 * @memberof syft_proto.execution.v1.PlaceholderId
-                 * @static
-                 * @param {Object.<string,*>} object Plain object
-                 * @returns {syft_proto.execution.v1.PlaceholderId} PlaceholderId
-                 */
-                PlaceholderId.fromObject = function fromObject(object) {
-                    if (object instanceof $root.syft_proto.execution.v1.PlaceholderId)
-                        return object;
-                    var message = new $root.syft_proto.execution.v1.PlaceholderId();
-                    if (object.id != null) {
-                        if (typeof object.id !== "object")
-                            throw TypeError(".syft_proto.execution.v1.PlaceholderId.id: object expected");
-                        message.id = $root.syft_proto.types.syft.v1.Id.fromObject(object.id);
-                    }
-                    return message;
-                };
-
-                /**
-                 * Creates a plain object from a PlaceholderId message. Also converts values to other types if specified.
-                 * @function toObject
-                 * @memberof syft_proto.execution.v1.PlaceholderId
-                 * @static
-                 * @param {syft_proto.execution.v1.PlaceholderId} message PlaceholderId
-                 * @param {$protobuf.IConversionOptions} [options] Conversion options
-                 * @returns {Object.<string,*>} Plain object
-                 */
-                PlaceholderId.toObject = function toObject(message, options) {
-                    if (!options)
-                        options = {};
-                    var object = {};
-                    if (options.defaults)
-                        object.id = null;
-                    if (message.id != null && message.hasOwnProperty("id"))
-                        object.id = $root.syft_proto.types.syft.v1.Id.toObject(message.id, options);
-                    return object;
-                };
-
-                /**
-                 * Converts this PlaceholderId to JSON.
-                 * @function toJSON
-                 * @memberof syft_proto.execution.v1.PlaceholderId
-                 * @instance
-                 * @returns {Object.<string,*>} JSON object
-                 */
-                PlaceholderId.prototype.toJSON = function toJSON() {
-                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-                };
-
-                return PlaceholderId;
             })();
 
             v1.ComputationAction = (function() {
@@ -4381,6 +4562,460 @@ $root.syft_proto = (function() {
                  */
                 var v1 = {};
 
+                v1.Id = (function() {
+
+                    /**
+                     * Properties of an Id.
+                     * @memberof syft_proto.types.syft.v1
+                     * @interface IId
+                     * @property {number|Long|null} [id_int] Id id_int
+                     * @property {string|null} [id_str] Id id_str
+                     */
+
+                    /**
+                     * Constructs a new Id.
+                     * @memberof syft_proto.types.syft.v1
+                     * @classdesc Represents an Id.
+                     * @implements IId
+                     * @constructor
+                     * @param {syft_proto.types.syft.v1.IId=} [properties] Properties to set
+                     */
+                    function Id(properties) {
+                        if (properties)
+                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+
+                    /**
+                     * Id id_int.
+                     * @member {number|Long} id_int
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @instance
+                     */
+                    Id.prototype.id_int = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+                    /**
+                     * Id id_str.
+                     * @member {string} id_str
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @instance
+                     */
+                    Id.prototype.id_str = "";
+
+                    // OneOf field names bound to virtual getters and setters
+                    var $oneOfFields;
+
+                    /**
+                     * Id id.
+                     * @member {"id_int"|"id_str"|undefined} id
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @instance
+                     */
+                    Object.defineProperty(Id.prototype, "id", {
+                        get: $util.oneOfGetter($oneOfFields = ["id_int", "id_str"]),
+                        set: $util.oneOfSetter($oneOfFields)
+                    });
+
+                    /**
+                     * Creates a new Id instance using the specified properties.
+                     * @function create
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @static
+                     * @param {syft_proto.types.syft.v1.IId=} [properties] Properties to set
+                     * @returns {syft_proto.types.syft.v1.Id} Id instance
+                     */
+                    Id.create = function create(properties) {
+                        return new Id(properties);
+                    };
+
+                    /**
+                     * Encodes the specified Id message. Does not implicitly {@link syft_proto.types.syft.v1.Id.verify|verify} messages.
+                     * @function encode
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @static
+                     * @param {syft_proto.types.syft.v1.IId} message Id message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    Id.encode = function encode(message, writer) {
+                        if (!writer)
+                            writer = $Writer.create();
+                        if (message.id_int != null && message.hasOwnProperty("id_int"))
+                            writer.uint32(/* id 1, wireType 0 =*/8).int64(message.id_int);
+                        if (message.id_str != null && message.hasOwnProperty("id_str"))
+                            writer.uint32(/* id 2, wireType 2 =*/18).string(message.id_str);
+                        return writer;
+                    };
+
+                    /**
+                     * Encodes the specified Id message, length delimited. Does not implicitly {@link syft_proto.types.syft.v1.Id.verify|verify} messages.
+                     * @function encodeDelimited
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @static
+                     * @param {syft_proto.types.syft.v1.IId} message Id message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    Id.encodeDelimited = function encodeDelimited(message, writer) {
+                        return this.encode(message, writer).ldelim();
+                    };
+
+                    /**
+                     * Decodes an Id message from the specified reader or buffer.
+                     * @function decode
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @param {number} [length] Message length if known beforehand
+                     * @returns {syft_proto.types.syft.v1.Id} Id
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    Id.decode = function decode(reader, length) {
+                        if (!(reader instanceof $Reader))
+                            reader = $Reader.create(reader);
+                        var end = length === undefined ? reader.len : reader.pos + length, message = new $root.syft_proto.types.syft.v1.Id();
+                        while (reader.pos < end) {
+                            var tag = reader.uint32();
+                            switch (tag >>> 3) {
+                            case 1:
+                                message.id_int = reader.int64();
+                                break;
+                            case 2:
+                                message.id_str = reader.string();
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                            }
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Decodes an Id message from the specified reader or buffer, length delimited.
+                     * @function decodeDelimited
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @returns {syft_proto.types.syft.v1.Id} Id
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    Id.decodeDelimited = function decodeDelimited(reader) {
+                        if (!(reader instanceof $Reader))
+                            reader = new $Reader(reader);
+                        return this.decode(reader, reader.uint32());
+                    };
+
+                    /**
+                     * Verifies an Id message.
+                     * @function verify
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @static
+                     * @param {Object.<string,*>} message Plain object to verify
+                     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                     */
+                    Id.verify = function verify(message) {
+                        if (typeof message !== "object" || message === null)
+                            return "object expected";
+                        var properties = {};
+                        if (message.id_int != null && message.hasOwnProperty("id_int")) {
+                            properties.id = 1;
+                            if (!$util.isInteger(message.id_int) && !(message.id_int && $util.isInteger(message.id_int.low) && $util.isInteger(message.id_int.high)))
+                                return "id_int: integer|Long expected";
+                        }
+                        if (message.id_str != null && message.hasOwnProperty("id_str")) {
+                            if (properties.id === 1)
+                                return "id: multiple values";
+                            properties.id = 1;
+                            if (!$util.isString(message.id_str))
+                                return "id_str: string expected";
+                        }
+                        return null;
+                    };
+
+                    /**
+                     * Creates an Id message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {syft_proto.types.syft.v1.Id} Id
+                     */
+                    Id.fromObject = function fromObject(object) {
+                        if (object instanceof $root.syft_proto.types.syft.v1.Id)
+                            return object;
+                        var message = new $root.syft_proto.types.syft.v1.Id();
+                        if (object.id_int != null)
+                            if ($util.Long)
+                                (message.id_int = $util.Long.fromValue(object.id_int)).unsigned = false;
+                            else if (typeof object.id_int === "string")
+                                message.id_int = parseInt(object.id_int, 10);
+                            else if (typeof object.id_int === "number")
+                                message.id_int = object.id_int;
+                            else if (typeof object.id_int === "object")
+                                message.id_int = new $util.LongBits(object.id_int.low >>> 0, object.id_int.high >>> 0).toNumber();
+                        if (object.id_str != null)
+                            message.id_str = String(object.id_str);
+                        return message;
+                    };
+
+                    /**
+                     * Creates a plain object from an Id message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @static
+                     * @param {syft_proto.types.syft.v1.Id} message Id
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    Id.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        var object = {};
+                        if (message.id_int != null && message.hasOwnProperty("id_int")) {
+                            if (typeof message.id_int === "number")
+                                object.id_int = options.longs === String ? String(message.id_int) : message.id_int;
+                            else
+                                object.id_int = options.longs === String ? $util.Long.prototype.toString.call(message.id_int) : options.longs === Number ? new $util.LongBits(message.id_int.low >>> 0, message.id_int.high >>> 0).toNumber() : message.id_int;
+                            if (options.oneofs)
+                                object.id = "id_int";
+                        }
+                        if (message.id_str != null && message.hasOwnProperty("id_str")) {
+                            object.id_str = message.id_str;
+                            if (options.oneofs)
+                                object.id = "id_str";
+                        }
+                        return object;
+                    };
+
+                    /**
+                     * Converts this Id to JSON.
+                     * @function toJSON
+                     * @memberof syft_proto.types.syft.v1.Id
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    Id.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+
+                    return Id;
+                })();
+
+                v1.Shape = (function() {
+
+                    /**
+                     * Properties of a Shape.
+                     * @memberof syft_proto.types.syft.v1
+                     * @interface IShape
+                     * @property {Array.<number>|null} [dims] Shape dims
+                     */
+
+                    /**
+                     * Constructs a new Shape.
+                     * @memberof syft_proto.types.syft.v1
+                     * @classdesc Represents a Shape.
+                     * @implements IShape
+                     * @constructor
+                     * @param {syft_proto.types.syft.v1.IShape=} [properties] Properties to set
+                     */
+                    function Shape(properties) {
+                        this.dims = [];
+                        if (properties)
+                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+
+                    /**
+                     * Shape dims.
+                     * @member {Array.<number>} dims
+                     * @memberof syft_proto.types.syft.v1.Shape
+                     * @instance
+                     */
+                    Shape.prototype.dims = $util.emptyArray;
+
+                    /**
+                     * Creates a new Shape instance using the specified properties.
+                     * @function create
+                     * @memberof syft_proto.types.syft.v1.Shape
+                     * @static
+                     * @param {syft_proto.types.syft.v1.IShape=} [properties] Properties to set
+                     * @returns {syft_proto.types.syft.v1.Shape} Shape instance
+                     */
+                    Shape.create = function create(properties) {
+                        return new Shape(properties);
+                    };
+
+                    /**
+                     * Encodes the specified Shape message. Does not implicitly {@link syft_proto.types.syft.v1.Shape.verify|verify} messages.
+                     * @function encode
+                     * @memberof syft_proto.types.syft.v1.Shape
+                     * @static
+                     * @param {syft_proto.types.syft.v1.IShape} message Shape message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    Shape.encode = function encode(message, writer) {
+                        if (!writer)
+                            writer = $Writer.create();
+                        if (message.dims != null && message.dims.length) {
+                            writer.uint32(/* id 1, wireType 2 =*/10).fork();
+                            for (var i = 0; i < message.dims.length; ++i)
+                                writer.int32(message.dims[i]);
+                            writer.ldelim();
+                        }
+                        return writer;
+                    };
+
+                    /**
+                     * Encodes the specified Shape message, length delimited. Does not implicitly {@link syft_proto.types.syft.v1.Shape.verify|verify} messages.
+                     * @function encodeDelimited
+                     * @memberof syft_proto.types.syft.v1.Shape
+                     * @static
+                     * @param {syft_proto.types.syft.v1.IShape} message Shape message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    Shape.encodeDelimited = function encodeDelimited(message, writer) {
+                        return this.encode(message, writer).ldelim();
+                    };
+
+                    /**
+                     * Decodes a Shape message from the specified reader or buffer.
+                     * @function decode
+                     * @memberof syft_proto.types.syft.v1.Shape
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @param {number} [length] Message length if known beforehand
+                     * @returns {syft_proto.types.syft.v1.Shape} Shape
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    Shape.decode = function decode(reader, length) {
+                        if (!(reader instanceof $Reader))
+                            reader = $Reader.create(reader);
+                        var end = length === undefined ? reader.len : reader.pos + length, message = new $root.syft_proto.types.syft.v1.Shape();
+                        while (reader.pos < end) {
+                            var tag = reader.uint32();
+                            switch (tag >>> 3) {
+                            case 1:
+                                if (!(message.dims && message.dims.length))
+                                    message.dims = [];
+                                if ((tag & 7) === 2) {
+                                    var end2 = reader.uint32() + reader.pos;
+                                    while (reader.pos < end2)
+                                        message.dims.push(reader.int32());
+                                } else
+                                    message.dims.push(reader.int32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                            }
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Decodes a Shape message from the specified reader or buffer, length delimited.
+                     * @function decodeDelimited
+                     * @memberof syft_proto.types.syft.v1.Shape
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @returns {syft_proto.types.syft.v1.Shape} Shape
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    Shape.decodeDelimited = function decodeDelimited(reader) {
+                        if (!(reader instanceof $Reader))
+                            reader = new $Reader(reader);
+                        return this.decode(reader, reader.uint32());
+                    };
+
+                    /**
+                     * Verifies a Shape message.
+                     * @function verify
+                     * @memberof syft_proto.types.syft.v1.Shape
+                     * @static
+                     * @param {Object.<string,*>} message Plain object to verify
+                     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                     */
+                    Shape.verify = function verify(message) {
+                        if (typeof message !== "object" || message === null)
+                            return "object expected";
+                        if (message.dims != null && message.hasOwnProperty("dims")) {
+                            if (!Array.isArray(message.dims))
+                                return "dims: array expected";
+                            for (var i = 0; i < message.dims.length; ++i)
+                                if (!$util.isInteger(message.dims[i]))
+                                    return "dims: integer[] expected";
+                        }
+                        return null;
+                    };
+
+                    /**
+                     * Creates a Shape message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof syft_proto.types.syft.v1.Shape
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {syft_proto.types.syft.v1.Shape} Shape
+                     */
+                    Shape.fromObject = function fromObject(object) {
+                        if (object instanceof $root.syft_proto.types.syft.v1.Shape)
+                            return object;
+                        var message = new $root.syft_proto.types.syft.v1.Shape();
+                        if (object.dims) {
+                            if (!Array.isArray(object.dims))
+                                throw TypeError(".syft_proto.types.syft.v1.Shape.dims: array expected");
+                            message.dims = [];
+                            for (var i = 0; i < object.dims.length; ++i)
+                                message.dims[i] = object.dims[i] | 0;
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Creates a plain object from a Shape message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof syft_proto.types.syft.v1.Shape
+                     * @static
+                     * @param {syft_proto.types.syft.v1.Shape} message Shape
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    Shape.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        var object = {};
+                        if (options.arrays || options.defaults)
+                            object.dims = [];
+                        if (message.dims && message.dims.length) {
+                            object.dims = [];
+                            for (var j = 0; j < message.dims.length; ++j)
+                                object.dims[j] = message.dims[j];
+                        }
+                        return object;
+                    };
+
+                    /**
+                     * Converts this Shape to JSON.
+                     * @function toJSON
+                     * @memberof syft_proto.types.syft.v1.Shape
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    Shape.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+
+                    return Shape;
+                })();
+
                 v1.Arg = (function() {
 
                     /**
@@ -4872,460 +5507,6 @@ $root.syft_proto = (function() {
                     };
 
                     return Arg;
-                })();
-
-                v1.Id = (function() {
-
-                    /**
-                     * Properties of an Id.
-                     * @memberof syft_proto.types.syft.v1
-                     * @interface IId
-                     * @property {number|Long|null} [id_int] Id id_int
-                     * @property {string|null} [id_str] Id id_str
-                     */
-
-                    /**
-                     * Constructs a new Id.
-                     * @memberof syft_proto.types.syft.v1
-                     * @classdesc Represents an Id.
-                     * @implements IId
-                     * @constructor
-                     * @param {syft_proto.types.syft.v1.IId=} [properties] Properties to set
-                     */
-                    function Id(properties) {
-                        if (properties)
-                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                                if (properties[keys[i]] != null)
-                                    this[keys[i]] = properties[keys[i]];
-                    }
-
-                    /**
-                     * Id id_int.
-                     * @member {number|Long} id_int
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @instance
-                     */
-                    Id.prototype.id_int = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
-
-                    /**
-                     * Id id_str.
-                     * @member {string} id_str
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @instance
-                     */
-                    Id.prototype.id_str = "";
-
-                    // OneOf field names bound to virtual getters and setters
-                    var $oneOfFields;
-
-                    /**
-                     * Id id.
-                     * @member {"id_int"|"id_str"|undefined} id
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @instance
-                     */
-                    Object.defineProperty(Id.prototype, "id", {
-                        get: $util.oneOfGetter($oneOfFields = ["id_int", "id_str"]),
-                        set: $util.oneOfSetter($oneOfFields)
-                    });
-
-                    /**
-                     * Creates a new Id instance using the specified properties.
-                     * @function create
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @static
-                     * @param {syft_proto.types.syft.v1.IId=} [properties] Properties to set
-                     * @returns {syft_proto.types.syft.v1.Id} Id instance
-                     */
-                    Id.create = function create(properties) {
-                        return new Id(properties);
-                    };
-
-                    /**
-                     * Encodes the specified Id message. Does not implicitly {@link syft_proto.types.syft.v1.Id.verify|verify} messages.
-                     * @function encode
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @static
-                     * @param {syft_proto.types.syft.v1.IId} message Id message or plain object to encode
-                     * @param {$protobuf.Writer} [writer] Writer to encode to
-                     * @returns {$protobuf.Writer} Writer
-                     */
-                    Id.encode = function encode(message, writer) {
-                        if (!writer)
-                            writer = $Writer.create();
-                        if (message.id_int != null && message.hasOwnProperty("id_int"))
-                            writer.uint32(/* id 1, wireType 0 =*/8).int64(message.id_int);
-                        if (message.id_str != null && message.hasOwnProperty("id_str"))
-                            writer.uint32(/* id 2, wireType 2 =*/18).string(message.id_str);
-                        return writer;
-                    };
-
-                    /**
-                     * Encodes the specified Id message, length delimited. Does not implicitly {@link syft_proto.types.syft.v1.Id.verify|verify} messages.
-                     * @function encodeDelimited
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @static
-                     * @param {syft_proto.types.syft.v1.IId} message Id message or plain object to encode
-                     * @param {$protobuf.Writer} [writer] Writer to encode to
-                     * @returns {$protobuf.Writer} Writer
-                     */
-                    Id.encodeDelimited = function encodeDelimited(message, writer) {
-                        return this.encode(message, writer).ldelim();
-                    };
-
-                    /**
-                     * Decodes an Id message from the specified reader or buffer.
-                     * @function decode
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @static
-                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                     * @param {number} [length] Message length if known beforehand
-                     * @returns {syft_proto.types.syft.v1.Id} Id
-                     * @throws {Error} If the payload is not a reader or valid buffer
-                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                     */
-                    Id.decode = function decode(reader, length) {
-                        if (!(reader instanceof $Reader))
-                            reader = $Reader.create(reader);
-                        var end = length === undefined ? reader.len : reader.pos + length, message = new $root.syft_proto.types.syft.v1.Id();
-                        while (reader.pos < end) {
-                            var tag = reader.uint32();
-                            switch (tag >>> 3) {
-                            case 1:
-                                message.id_int = reader.int64();
-                                break;
-                            case 2:
-                                message.id_str = reader.string();
-                                break;
-                            default:
-                                reader.skipType(tag & 7);
-                                break;
-                            }
-                        }
-                        return message;
-                    };
-
-                    /**
-                     * Decodes an Id message from the specified reader or buffer, length delimited.
-                     * @function decodeDelimited
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @static
-                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                     * @returns {syft_proto.types.syft.v1.Id} Id
-                     * @throws {Error} If the payload is not a reader or valid buffer
-                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                     */
-                    Id.decodeDelimited = function decodeDelimited(reader) {
-                        if (!(reader instanceof $Reader))
-                            reader = new $Reader(reader);
-                        return this.decode(reader, reader.uint32());
-                    };
-
-                    /**
-                     * Verifies an Id message.
-                     * @function verify
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @static
-                     * @param {Object.<string,*>} message Plain object to verify
-                     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-                     */
-                    Id.verify = function verify(message) {
-                        if (typeof message !== "object" || message === null)
-                            return "object expected";
-                        var properties = {};
-                        if (message.id_int != null && message.hasOwnProperty("id_int")) {
-                            properties.id = 1;
-                            if (!$util.isInteger(message.id_int) && !(message.id_int && $util.isInteger(message.id_int.low) && $util.isInteger(message.id_int.high)))
-                                return "id_int: integer|Long expected";
-                        }
-                        if (message.id_str != null && message.hasOwnProperty("id_str")) {
-                            if (properties.id === 1)
-                                return "id: multiple values";
-                            properties.id = 1;
-                            if (!$util.isString(message.id_str))
-                                return "id_str: string expected";
-                        }
-                        return null;
-                    };
-
-                    /**
-                     * Creates an Id message from a plain object. Also converts values to their respective internal types.
-                     * @function fromObject
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @static
-                     * @param {Object.<string,*>} object Plain object
-                     * @returns {syft_proto.types.syft.v1.Id} Id
-                     */
-                    Id.fromObject = function fromObject(object) {
-                        if (object instanceof $root.syft_proto.types.syft.v1.Id)
-                            return object;
-                        var message = new $root.syft_proto.types.syft.v1.Id();
-                        if (object.id_int != null)
-                            if ($util.Long)
-                                (message.id_int = $util.Long.fromValue(object.id_int)).unsigned = false;
-                            else if (typeof object.id_int === "string")
-                                message.id_int = parseInt(object.id_int, 10);
-                            else if (typeof object.id_int === "number")
-                                message.id_int = object.id_int;
-                            else if (typeof object.id_int === "object")
-                                message.id_int = new $util.LongBits(object.id_int.low >>> 0, object.id_int.high >>> 0).toNumber();
-                        if (object.id_str != null)
-                            message.id_str = String(object.id_str);
-                        return message;
-                    };
-
-                    /**
-                     * Creates a plain object from an Id message. Also converts values to other types if specified.
-                     * @function toObject
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @static
-                     * @param {syft_proto.types.syft.v1.Id} message Id
-                     * @param {$protobuf.IConversionOptions} [options] Conversion options
-                     * @returns {Object.<string,*>} Plain object
-                     */
-                    Id.toObject = function toObject(message, options) {
-                        if (!options)
-                            options = {};
-                        var object = {};
-                        if (message.id_int != null && message.hasOwnProperty("id_int")) {
-                            if (typeof message.id_int === "number")
-                                object.id_int = options.longs === String ? String(message.id_int) : message.id_int;
-                            else
-                                object.id_int = options.longs === String ? $util.Long.prototype.toString.call(message.id_int) : options.longs === Number ? new $util.LongBits(message.id_int.low >>> 0, message.id_int.high >>> 0).toNumber() : message.id_int;
-                            if (options.oneofs)
-                                object.id = "id_int";
-                        }
-                        if (message.id_str != null && message.hasOwnProperty("id_str")) {
-                            object.id_str = message.id_str;
-                            if (options.oneofs)
-                                object.id = "id_str";
-                        }
-                        return object;
-                    };
-
-                    /**
-                     * Converts this Id to JSON.
-                     * @function toJSON
-                     * @memberof syft_proto.types.syft.v1.Id
-                     * @instance
-                     * @returns {Object.<string,*>} JSON object
-                     */
-                    Id.prototype.toJSON = function toJSON() {
-                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-                    };
-
-                    return Id;
-                })();
-
-                v1.Shape = (function() {
-
-                    /**
-                     * Properties of a Shape.
-                     * @memberof syft_proto.types.syft.v1
-                     * @interface IShape
-                     * @property {Array.<number>|null} [dims] Shape dims
-                     */
-
-                    /**
-                     * Constructs a new Shape.
-                     * @memberof syft_proto.types.syft.v1
-                     * @classdesc Represents a Shape.
-                     * @implements IShape
-                     * @constructor
-                     * @param {syft_proto.types.syft.v1.IShape=} [properties] Properties to set
-                     */
-                    function Shape(properties) {
-                        this.dims = [];
-                        if (properties)
-                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                                if (properties[keys[i]] != null)
-                                    this[keys[i]] = properties[keys[i]];
-                    }
-
-                    /**
-                     * Shape dims.
-                     * @member {Array.<number>} dims
-                     * @memberof syft_proto.types.syft.v1.Shape
-                     * @instance
-                     */
-                    Shape.prototype.dims = $util.emptyArray;
-
-                    /**
-                     * Creates a new Shape instance using the specified properties.
-                     * @function create
-                     * @memberof syft_proto.types.syft.v1.Shape
-                     * @static
-                     * @param {syft_proto.types.syft.v1.IShape=} [properties] Properties to set
-                     * @returns {syft_proto.types.syft.v1.Shape} Shape instance
-                     */
-                    Shape.create = function create(properties) {
-                        return new Shape(properties);
-                    };
-
-                    /**
-                     * Encodes the specified Shape message. Does not implicitly {@link syft_proto.types.syft.v1.Shape.verify|verify} messages.
-                     * @function encode
-                     * @memberof syft_proto.types.syft.v1.Shape
-                     * @static
-                     * @param {syft_proto.types.syft.v1.IShape} message Shape message or plain object to encode
-                     * @param {$protobuf.Writer} [writer] Writer to encode to
-                     * @returns {$protobuf.Writer} Writer
-                     */
-                    Shape.encode = function encode(message, writer) {
-                        if (!writer)
-                            writer = $Writer.create();
-                        if (message.dims != null && message.dims.length) {
-                            writer.uint32(/* id 1, wireType 2 =*/10).fork();
-                            for (var i = 0; i < message.dims.length; ++i)
-                                writer.int32(message.dims[i]);
-                            writer.ldelim();
-                        }
-                        return writer;
-                    };
-
-                    /**
-                     * Encodes the specified Shape message, length delimited. Does not implicitly {@link syft_proto.types.syft.v1.Shape.verify|verify} messages.
-                     * @function encodeDelimited
-                     * @memberof syft_proto.types.syft.v1.Shape
-                     * @static
-                     * @param {syft_proto.types.syft.v1.IShape} message Shape message or plain object to encode
-                     * @param {$protobuf.Writer} [writer] Writer to encode to
-                     * @returns {$protobuf.Writer} Writer
-                     */
-                    Shape.encodeDelimited = function encodeDelimited(message, writer) {
-                        return this.encode(message, writer).ldelim();
-                    };
-
-                    /**
-                     * Decodes a Shape message from the specified reader or buffer.
-                     * @function decode
-                     * @memberof syft_proto.types.syft.v1.Shape
-                     * @static
-                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                     * @param {number} [length] Message length if known beforehand
-                     * @returns {syft_proto.types.syft.v1.Shape} Shape
-                     * @throws {Error} If the payload is not a reader or valid buffer
-                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                     */
-                    Shape.decode = function decode(reader, length) {
-                        if (!(reader instanceof $Reader))
-                            reader = $Reader.create(reader);
-                        var end = length === undefined ? reader.len : reader.pos + length, message = new $root.syft_proto.types.syft.v1.Shape();
-                        while (reader.pos < end) {
-                            var tag = reader.uint32();
-                            switch (tag >>> 3) {
-                            case 1:
-                                if (!(message.dims && message.dims.length))
-                                    message.dims = [];
-                                if ((tag & 7) === 2) {
-                                    var end2 = reader.uint32() + reader.pos;
-                                    while (reader.pos < end2)
-                                        message.dims.push(reader.int32());
-                                } else
-                                    message.dims.push(reader.int32());
-                                break;
-                            default:
-                                reader.skipType(tag & 7);
-                                break;
-                            }
-                        }
-                        return message;
-                    };
-
-                    /**
-                     * Decodes a Shape message from the specified reader or buffer, length delimited.
-                     * @function decodeDelimited
-                     * @memberof syft_proto.types.syft.v1.Shape
-                     * @static
-                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                     * @returns {syft_proto.types.syft.v1.Shape} Shape
-                     * @throws {Error} If the payload is not a reader or valid buffer
-                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                     */
-                    Shape.decodeDelimited = function decodeDelimited(reader) {
-                        if (!(reader instanceof $Reader))
-                            reader = new $Reader(reader);
-                        return this.decode(reader, reader.uint32());
-                    };
-
-                    /**
-                     * Verifies a Shape message.
-                     * @function verify
-                     * @memberof syft_proto.types.syft.v1.Shape
-                     * @static
-                     * @param {Object.<string,*>} message Plain object to verify
-                     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-                     */
-                    Shape.verify = function verify(message) {
-                        if (typeof message !== "object" || message === null)
-                            return "object expected";
-                        if (message.dims != null && message.hasOwnProperty("dims")) {
-                            if (!Array.isArray(message.dims))
-                                return "dims: array expected";
-                            for (var i = 0; i < message.dims.length; ++i)
-                                if (!$util.isInteger(message.dims[i]))
-                                    return "dims: integer[] expected";
-                        }
-                        return null;
-                    };
-
-                    /**
-                     * Creates a Shape message from a plain object. Also converts values to their respective internal types.
-                     * @function fromObject
-                     * @memberof syft_proto.types.syft.v1.Shape
-                     * @static
-                     * @param {Object.<string,*>} object Plain object
-                     * @returns {syft_proto.types.syft.v1.Shape} Shape
-                     */
-                    Shape.fromObject = function fromObject(object) {
-                        if (object instanceof $root.syft_proto.types.syft.v1.Shape)
-                            return object;
-                        var message = new $root.syft_proto.types.syft.v1.Shape();
-                        if (object.dims) {
-                            if (!Array.isArray(object.dims))
-                                throw TypeError(".syft_proto.types.syft.v1.Shape.dims: array expected");
-                            message.dims = [];
-                            for (var i = 0; i < object.dims.length; ++i)
-                                message.dims[i] = object.dims[i] | 0;
-                        }
-                        return message;
-                    };
-
-                    /**
-                     * Creates a plain object from a Shape message. Also converts values to other types if specified.
-                     * @function toObject
-                     * @memberof syft_proto.types.syft.v1.Shape
-                     * @static
-                     * @param {syft_proto.types.syft.v1.Shape} message Shape
-                     * @param {$protobuf.IConversionOptions} [options] Conversion options
-                     * @returns {Object.<string,*>} Plain object
-                     */
-                    Shape.toObject = function toObject(message, options) {
-                        if (!options)
-                            options = {};
-                        var object = {};
-                        if (options.arrays || options.defaults)
-                            object.dims = [];
-                        if (message.dims && message.dims.length) {
-                            object.dims = [];
-                            for (var j = 0; j < message.dims.length; ++j)
-                                object.dims[j] = message.dims[j];
-                        }
-                        return object;
-                    };
-
-                    /**
-                     * Converts this Shape to JSON.
-                     * @function toJSON
-                     * @memberof syft_proto.types.syft.v1.Shape
-                     * @instance
-                     * @returns {Object.<string,*>} JSON object
-                     */
-                    Shape.prototype.toJSON = function toJSON() {
-                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-                    };
-
-                    return Shape;
                 })();
 
                 return v1;

--- a/jvm/src/main/java/org/openmined/syftproto/execution/v1/CommunicationActionOuterClass.java
+++ b/jvm/src/main/java/org/openmined/syftproto/execution/v1/CommunicationActionOuterClass.java
@@ -19,77 +19,107 @@ public final class CommunicationActionOuterClass {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>string name = 1[json_name = "name"];</code>
-     * @return The name.
+     * <code>string command = 1[json_name = "command"];</code>
+     * @return The command.
      */
-    java.lang.String getName();
+    java.lang.String getCommand();
     /**
-     * <code>string name = 1[json_name = "name"];</code>
-     * @return The bytes for name.
+     * <code>string command = 1[json_name = "command"];</code>
+     * @return The bytes for command.
      */
     com.google.protobuf.ByteString
-        getNameBytes();
+        getCommandBytes();
 
     /**
-     * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
-     * @return Whether the objId field is set.
+     * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
+     * @return Whether the targetId field is set.
      */
-    boolean hasObjId();
+    boolean hasTargetId();
     /**
-     * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
-     * @return The objId.
+     * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
+     * @return The targetId.
      */
-    org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getObjId();
+    org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getTargetId();
     /**
-     * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
+     * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
      */
-    org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getObjIdOrBuilder();
+    org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getTargetIdOrBuilder();
 
     /**
-     * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
-     * @return Whether the source field is set.
+     * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
+     * @return Whether the targetPointer field is set.
      */
-    boolean hasSource();
+    boolean hasTargetPointer();
     /**
-     * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
-     * @return The source.
+     * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
+     * @return The targetPointer.
      */
-    org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getSource();
+    org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor getTargetPointer();
     /**
-     * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
+     * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
      */
-    org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getSourceOrBuilder();
+    org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensorOrBuilder getTargetPointerOrBuilder();
 
     /**
-     * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+     * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+     * @return Whether the targetPlaceholderId field is set.
      */
-    java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> 
-        getDestinationsList();
+    boolean hasTargetPlaceholderId();
     /**
-     * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+     * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+     * @return The targetPlaceholderId.
      */
-    org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getDestinations(int index);
+    org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId getTargetPlaceholderId();
     /**
-     * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+     * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
      */
-    int getDestinationsCount();
+    org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder getTargetPlaceholderIdOrBuilder();
+
     /**
-     * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+     * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+     * @return Whether the targetTensor field is set.
      */
-    java.util.List<? extends org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> 
-        getDestinationsOrBuilderList();
+    boolean hasTargetTensor();
     /**
-     * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+     * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+     * @return The targetTensor.
      */
-    org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getDestinationsOrBuilder(
+    org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor getTargetTensor();
+    /**
+     * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+     */
+    org.openmined.syftproto.types.torch.v1.Tensor.TorchTensorOrBuilder getTargetTensorOrBuilder();
+
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
+     */
+    java.util.List<org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg> 
+        getArgsList();
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
+     */
+    org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg getArgs(int index);
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
+     */
+    int getArgsCount();
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
+     */
+    java.util.List<? extends org.openmined.syftproto.types.syft.v1.ArgOuterClass.ArgOrBuilder> 
+        getArgsOrBuilderList();
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
+     */
+    org.openmined.syftproto.types.syft.v1.ArgOuterClass.ArgOrBuilder getArgsOrBuilder(
         int index);
 
     /**
-     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
      */
     int getKwargsCount();
     /**
-     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
      */
     boolean containsKwargs(
         java.lang.String key);
@@ -100,23 +130,73 @@ public final class CommunicationActionOuterClass {
     java.util.Map<java.lang.String, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg>
     getKwargs();
     /**
-     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
      */
     java.util.Map<java.lang.String, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg>
     getKwargsMap();
     /**
-     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
      */
 
     org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg getKwargsOrDefault(
         java.lang.String key,
         org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg defaultValue);
     /**
-     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
      */
 
     org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg getKwargsOrThrow(
         java.lang.String key);
+
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+     */
+    java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> 
+        getReturnIdsList();
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+     */
+    org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getReturnIds(int index);
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+     */
+    int getReturnIdsCount();
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+     */
+    java.util.List<? extends org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> 
+        getReturnIdsOrBuilderList();
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+     */
+    org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getReturnIdsOrBuilder(
+        int index);
+
+    /**
+     * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+     */
+    java.util.List<org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId> 
+        getReturnPlaceholderIdsList();
+    /**
+     * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+     */
+    org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId getReturnPlaceholderIds(int index);
+    /**
+     * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+     */
+    int getReturnPlaceholderIdsCount();
+    /**
+     * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+     */
+    java.util.List<? extends org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder> 
+        getReturnPlaceholderIdsOrBuilderList();
+    /**
+     * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+     */
+    org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder getReturnPlaceholderIdsOrBuilder(
+        int index);
+
+    public org.openmined.syftproto.execution.v1.CommunicationActionOuterClass.CommunicationAction.TargetCase getTargetCase();
   }
   /**
    * Protobuf type {@code syft_proto.execution.v1.CommunicationAction}
@@ -131,8 +211,10 @@ public final class CommunicationActionOuterClass {
       super(builder);
     }
     private CommunicationAction() {
-      name_ = "";
-      destinations_ = java.util.Collections.emptyList();
+      command_ = "";
+      args_ = java.util.Collections.emptyList();
+      returnIds_ = java.util.Collections.emptyList();
+      returnPlaceholderIds_ = java.util.Collections.emptyList();
     }
 
     @java.lang.Override
@@ -169,45 +251,61 @@ public final class CommunicationActionOuterClass {
             case 10: {
               java.lang.String s = input.readStringRequireUtf8();
 
-              name_ = s;
+              command_ = s;
               break;
             }
             case 18: {
-              org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder subBuilder = null;
-              if (objId_ != null) {
-                subBuilder = objId_.toBuilder();
+              org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.Builder subBuilder = null;
+              if (targetCase_ == 2) {
+                subBuilder = ((org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor) target_).toBuilder();
               }
-              objId_ = input.readMessage(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.parser(), extensionRegistry);
+              target_ =
+                  input.readMessage(org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom(objId_);
-                objId_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor) target_);
+                target_ = subBuilder.buildPartial();
               }
-
+              targetCase_ = 2;
               break;
             }
             case 26: {
-              org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder subBuilder = null;
-              if (source_ != null) {
-                subBuilder = source_.toBuilder();
+              org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder subBuilder = null;
+              if (targetCase_ == 3) {
+                subBuilder = ((org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId) target_).toBuilder();
               }
-              source_ = input.readMessage(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.parser(), extensionRegistry);
+              target_ =
+                  input.readMessage(org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom(source_);
-                source_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId) target_);
+                target_ = subBuilder.buildPartial();
               }
-
+              targetCase_ = 3;
               break;
             }
             case 34: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                destinations_ = new java.util.ArrayList<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id>();
-                mutable_bitField0_ |= 0x00000001;
+              org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.Builder subBuilder = null;
+              if (targetCase_ == 4) {
+                subBuilder = ((org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor) target_).toBuilder();
               }
-              destinations_.add(
-                  input.readMessage(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.parser(), extensionRegistry));
+              target_ =
+                  input.readMessage(org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor) target_);
+                target_ = subBuilder.buildPartial();
+              }
+              targetCase_ = 4;
               break;
             }
             case 42: {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                args_ = new java.util.ArrayList<org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              args_.add(
+                  input.readMessage(org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.parser(), extensionRegistry));
+              break;
+            }
+            case 50: {
               if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                 kwargs_ = com.google.protobuf.MapField.newMapField(
                     KwargsDefaultEntryHolder.defaultEntry);
@@ -218,6 +316,38 @@ public final class CommunicationActionOuterClass {
                   KwargsDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               kwargs_.getMutableMap().put(
                   kwargs__.getKey(), kwargs__.getValue());
+              break;
+            }
+            case 58: {
+              if (!((mutable_bitField0_ & 0x00000004) != 0)) {
+                returnIds_ = new java.util.ArrayList<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id>();
+                mutable_bitField0_ |= 0x00000004;
+              }
+              returnIds_.add(
+                  input.readMessage(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.parser(), extensionRegistry));
+              break;
+            }
+            case 66: {
+              if (!((mutable_bitField0_ & 0x00000008) != 0)) {
+                returnPlaceholderIds_ = new java.util.ArrayList<org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId>();
+                mutable_bitField0_ |= 0x00000008;
+              }
+              returnPlaceholderIds_.add(
+                  input.readMessage(org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.parser(), extensionRegistry));
+              break;
+            }
+            case 74: {
+              org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder subBuilder = null;
+              if (targetCase_ == 9) {
+                subBuilder = ((org.openmined.syftproto.types.syft.v1.IdOuterClass.Id) target_).toBuilder();
+              }
+              target_ =
+                  input.readMessage(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((org.openmined.syftproto.types.syft.v1.IdOuterClass.Id) target_);
+                target_ = subBuilder.buildPartial();
+              }
+              targetCase_ = 9;
               break;
             }
             default: {
@@ -236,7 +366,13 @@ public final class CommunicationActionOuterClass {
             e).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) != 0)) {
-          destinations_ = java.util.Collections.unmodifiableList(destinations_);
+          args_ = java.util.Collections.unmodifiableList(args_);
+        }
+        if (((mutable_bitField0_ & 0x00000004) != 0)) {
+          returnIds_ = java.util.Collections.unmodifiableList(returnIds_);
+        }
+        if (((mutable_bitField0_ & 0x00000008) != 0)) {
+          returnPlaceholderIds_ = java.util.Collections.unmodifiableList(returnPlaceholderIds_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -252,7 +388,7 @@ public final class CommunicationActionOuterClass {
     protected com.google.protobuf.MapField internalGetMapField(
         int number) {
       switch (number) {
-        case 5:
+        case 6:
           return internalGetKwargs();
         default:
           throw new RuntimeException(
@@ -267,124 +403,235 @@ public final class CommunicationActionOuterClass {
               org.openmined.syftproto.execution.v1.CommunicationActionOuterClass.CommunicationAction.class, org.openmined.syftproto.execution.v1.CommunicationActionOuterClass.CommunicationAction.Builder.class);
     }
 
-    public static final int NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object name_;
+    private int targetCase_ = 0;
+    private java.lang.Object target_;
+    public enum TargetCase
+        implements com.google.protobuf.Internal.EnumLite,
+            com.google.protobuf.AbstractMessage.InternalOneOfEnum {
+      TARGET_ID(9),
+      TARGET_POINTER(2),
+      TARGET_PLACEHOLDER_ID(3),
+      TARGET_TENSOR(4),
+      TARGET_NOT_SET(0);
+      private final int value;
+      private TargetCase(int value) {
+        this.value = value;
+      }
+      /**
+       * @param value The number of the enum to look for.
+       * @return The enum associated with the given number.
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
+      public static TargetCase valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static TargetCase forNumber(int value) {
+        switch (value) {
+          case 9: return TARGET_ID;
+          case 2: return TARGET_POINTER;
+          case 3: return TARGET_PLACEHOLDER_ID;
+          case 4: return TARGET_TENSOR;
+          case 0: return TARGET_NOT_SET;
+          default: return null;
+        }
+      }
+      public int getNumber() {
+        return this.value;
+      }
+    };
+
+    public TargetCase
+    getTargetCase() {
+      return TargetCase.forNumber(
+          targetCase_);
+    }
+
+    public static final int COMMAND_FIELD_NUMBER = 1;
+    private volatile java.lang.Object command_;
     /**
-     * <code>string name = 1[json_name = "name"];</code>
-     * @return The name.
+     * <code>string command = 1[json_name = "command"];</code>
+     * @return The command.
      */
-    public java.lang.String getName() {
-      java.lang.Object ref = name_;
+    public java.lang.String getCommand() {
+      java.lang.Object ref = command_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
-        name_ = s;
+        command_ = s;
         return s;
       }
     }
     /**
-     * <code>string name = 1[json_name = "name"];</code>
-     * @return The bytes for name.
+     * <code>string command = 1[json_name = "command"];</code>
+     * @return The bytes for command.
      */
     public com.google.protobuf.ByteString
-        getNameBytes() {
-      java.lang.Object ref = name_;
+        getCommandBytes() {
+      java.lang.Object ref = command_;
       if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
-        name_ = b;
+        command_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
 
-    public static final int OBJ_ID_FIELD_NUMBER = 2;
-    private org.openmined.syftproto.types.syft.v1.IdOuterClass.Id objId_;
+    public static final int TARGET_ID_FIELD_NUMBER = 9;
     /**
-     * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
-     * @return Whether the objId field is set.
+     * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
+     * @return Whether the targetId field is set.
      */
-    public boolean hasObjId() {
-      return objId_ != null;
+    public boolean hasTargetId() {
+      return targetCase_ == 9;
     }
     /**
-     * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
-     * @return The objId.
+     * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
+     * @return The targetId.
      */
-    public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getObjId() {
-      return objId_ == null ? org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance() : objId_;
+    public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getTargetId() {
+      if (targetCase_ == 9) {
+         return (org.openmined.syftproto.types.syft.v1.IdOuterClass.Id) target_;
+      }
+      return org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance();
     }
     /**
-     * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
+     * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
      */
-    public org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getObjIdOrBuilder() {
-      return getObjId();
-    }
-
-    public static final int SOURCE_FIELD_NUMBER = 3;
-    private org.openmined.syftproto.types.syft.v1.IdOuterClass.Id source_;
-    /**
-     * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
-     * @return Whether the source field is set.
-     */
-    public boolean hasSource() {
-      return source_ != null;
-    }
-    /**
-     * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
-     * @return The source.
-     */
-    public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getSource() {
-      return source_ == null ? org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance() : source_;
-    }
-    /**
-     * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
-     */
-    public org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getSourceOrBuilder() {
-      return getSource();
+    public org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getTargetIdOrBuilder() {
+      if (targetCase_ == 9) {
+         return (org.openmined.syftproto.types.syft.v1.IdOuterClass.Id) target_;
+      }
+      return org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance();
     }
 
-    public static final int DESTINATIONS_FIELD_NUMBER = 4;
-    private java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> destinations_;
+    public static final int TARGET_POINTER_FIELD_NUMBER = 2;
     /**
-     * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+     * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
+     * @return Whether the targetPointer field is set.
      */
-    public java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> getDestinationsList() {
-      return destinations_;
+    public boolean hasTargetPointer() {
+      return targetCase_ == 2;
     }
     /**
-     * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+     * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
+     * @return The targetPointer.
      */
-    public java.util.List<? extends org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> 
-        getDestinationsOrBuilderList() {
-      return destinations_;
+    public org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor getTargetPointer() {
+      if (targetCase_ == 2) {
+         return (org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor) target_;
+      }
+      return org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.getDefaultInstance();
     }
     /**
-     * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+     * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
      */
-    public int getDestinationsCount() {
-      return destinations_.size();
+    public org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensorOrBuilder getTargetPointerOrBuilder() {
+      if (targetCase_ == 2) {
+         return (org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor) target_;
+      }
+      return org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.getDefaultInstance();
+    }
+
+    public static final int TARGET_PLACEHOLDER_ID_FIELD_NUMBER = 3;
+    /**
+     * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+     * @return Whether the targetPlaceholderId field is set.
+     */
+    public boolean hasTargetPlaceholderId() {
+      return targetCase_ == 3;
     }
     /**
-     * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+     * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+     * @return The targetPlaceholderId.
      */
-    public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getDestinations(int index) {
-      return destinations_.get(index);
+    public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId getTargetPlaceholderId() {
+      if (targetCase_ == 3) {
+         return (org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId) target_;
+      }
+      return org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.getDefaultInstance();
     }
     /**
-     * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+     * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
      */
-    public org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getDestinationsOrBuilder(
+    public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder getTargetPlaceholderIdOrBuilder() {
+      if (targetCase_ == 3) {
+         return (org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId) target_;
+      }
+      return org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.getDefaultInstance();
+    }
+
+    public static final int TARGET_TENSOR_FIELD_NUMBER = 4;
+    /**
+     * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+     * @return Whether the targetTensor field is set.
+     */
+    public boolean hasTargetTensor() {
+      return targetCase_ == 4;
+    }
+    /**
+     * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+     * @return The targetTensor.
+     */
+    public org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor getTargetTensor() {
+      if (targetCase_ == 4) {
+         return (org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor) target_;
+      }
+      return org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.getDefaultInstance();
+    }
+    /**
+     * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+     */
+    public org.openmined.syftproto.types.torch.v1.Tensor.TorchTensorOrBuilder getTargetTensorOrBuilder() {
+      if (targetCase_ == 4) {
+         return (org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor) target_;
+      }
+      return org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.getDefaultInstance();
+    }
+
+    public static final int ARGS_FIELD_NUMBER = 5;
+    private java.util.List<org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg> args_;
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
+     */
+    public java.util.List<org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg> getArgsList() {
+      return args_;
+    }
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
+     */
+    public java.util.List<? extends org.openmined.syftproto.types.syft.v1.ArgOuterClass.ArgOrBuilder> 
+        getArgsOrBuilderList() {
+      return args_;
+    }
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
+     */
+    public int getArgsCount() {
+      return args_.size();
+    }
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
+     */
+    public org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg getArgs(int index) {
+      return args_.get(index);
+    }
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
+     */
+    public org.openmined.syftproto.types.syft.v1.ArgOuterClass.ArgOrBuilder getArgsOrBuilder(
         int index) {
-      return destinations_.get(index);
+      return args_.get(index);
     }
 
-    public static final int KWARGS_FIELD_NUMBER = 5;
+    public static final int KWARGS_FIELD_NUMBER = 6;
     private static final class KwargsDefaultEntryHolder {
       static final com.google.protobuf.MapEntry<
           java.lang.String, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg> defaultEntry =
@@ -411,7 +658,7 @@ public final class CommunicationActionOuterClass {
       return internalGetKwargs().getMap().size();
     }
     /**
-     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
      */
 
     public boolean containsKwargs(
@@ -427,14 +674,14 @@ public final class CommunicationActionOuterClass {
       return getKwargsMap();
     }
     /**
-     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
      */
 
     public java.util.Map<java.lang.String, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg> getKwargsMap() {
       return internalGetKwargs().getMap();
     }
     /**
-     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
      */
 
     public org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg getKwargsOrDefault(
@@ -446,7 +693,7 @@ public final class CommunicationActionOuterClass {
       return map.containsKey(key) ? map.get(key) : defaultValue;
     }
     /**
-     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+     * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
      */
 
     public org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg getKwargsOrThrow(
@@ -458,6 +705,76 @@ public final class CommunicationActionOuterClass {
         throw new java.lang.IllegalArgumentException();
       }
       return map.get(key);
+    }
+
+    public static final int RETURN_IDS_FIELD_NUMBER = 7;
+    private java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> returnIds_;
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+     */
+    public java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> getReturnIdsList() {
+      return returnIds_;
+    }
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+     */
+    public java.util.List<? extends org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> 
+        getReturnIdsOrBuilderList() {
+      return returnIds_;
+    }
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+     */
+    public int getReturnIdsCount() {
+      return returnIds_.size();
+    }
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+     */
+    public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getReturnIds(int index) {
+      return returnIds_.get(index);
+    }
+    /**
+     * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+     */
+    public org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getReturnIdsOrBuilder(
+        int index) {
+      return returnIds_.get(index);
+    }
+
+    public static final int RETURN_PLACEHOLDER_IDS_FIELD_NUMBER = 8;
+    private java.util.List<org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId> returnPlaceholderIds_;
+    /**
+     * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+     */
+    public java.util.List<org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId> getReturnPlaceholderIdsList() {
+      return returnPlaceholderIds_;
+    }
+    /**
+     * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+     */
+    public java.util.List<? extends org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder> 
+        getReturnPlaceholderIdsOrBuilderList() {
+      return returnPlaceholderIds_;
+    }
+    /**
+     * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+     */
+    public int getReturnPlaceholderIdsCount() {
+      return returnPlaceholderIds_.size();
+    }
+    /**
+     * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+     */
+    public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId getReturnPlaceholderIds(int index) {
+      return returnPlaceholderIds_.get(index);
+    }
+    /**
+     * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+     */
+    public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder getReturnPlaceholderIdsOrBuilder(
+        int index) {
+      return returnPlaceholderIds_.get(index);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -474,24 +791,36 @@ public final class CommunicationActionOuterClass {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getNameBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
+      if (!getCommandBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, command_);
       }
-      if (objId_ != null) {
-        output.writeMessage(2, getObjId());
+      if (targetCase_ == 2) {
+        output.writeMessage(2, (org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor) target_);
       }
-      if (source_ != null) {
-        output.writeMessage(3, getSource());
+      if (targetCase_ == 3) {
+        output.writeMessage(3, (org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId) target_);
       }
-      for (int i = 0; i < destinations_.size(); i++) {
-        output.writeMessage(4, destinations_.get(i));
+      if (targetCase_ == 4) {
+        output.writeMessage(4, (org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor) target_);
+      }
+      for (int i = 0; i < args_.size(); i++) {
+        output.writeMessage(5, args_.get(i));
       }
       com.google.protobuf.GeneratedMessageV3
         .serializeStringMapTo(
           output,
           internalGetKwargs(),
           KwargsDefaultEntryHolder.defaultEntry,
-          5);
+          6);
+      for (int i = 0; i < returnIds_.size(); i++) {
+        output.writeMessage(7, returnIds_.get(i));
+      }
+      for (int i = 0; i < returnPlaceholderIds_.size(); i++) {
+        output.writeMessage(8, returnPlaceholderIds_.get(i));
+      }
+      if (targetCase_ == 9) {
+        output.writeMessage(9, (org.openmined.syftproto.types.syft.v1.IdOuterClass.Id) target_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -501,20 +830,24 @@ public final class CommunicationActionOuterClass {
       if (size != -1) return size;
 
       size = 0;
-      if (!getNameBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
+      if (!getCommandBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, command_);
       }
-      if (objId_ != null) {
+      if (targetCase_ == 2) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(2, getObjId());
+          .computeMessageSize(2, (org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor) target_);
       }
-      if (source_ != null) {
+      if (targetCase_ == 3) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(3, getSource());
+          .computeMessageSize(3, (org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId) target_);
       }
-      for (int i = 0; i < destinations_.size(); i++) {
+      if (targetCase_ == 4) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(4, destinations_.get(i));
+          .computeMessageSize(4, (org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor) target_);
+      }
+      for (int i = 0; i < args_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(5, args_.get(i));
       }
       for (java.util.Map.Entry<java.lang.String, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg> entry
            : internalGetKwargs().getMap().entrySet()) {
@@ -524,7 +857,19 @@ public final class CommunicationActionOuterClass {
             .setValue(entry.getValue())
             .build();
         size += com.google.protobuf.CodedOutputStream
-            .computeMessageSize(5, kwargs__);
+            .computeMessageSize(6, kwargs__);
+      }
+      for (int i = 0; i < returnIds_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(7, returnIds_.get(i));
+      }
+      for (int i = 0; i < returnPlaceholderIds_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(8, returnPlaceholderIds_.get(i));
+      }
+      if (targetCase_ == 9) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(9, (org.openmined.syftproto.types.syft.v1.IdOuterClass.Id) target_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -541,22 +886,37 @@ public final class CommunicationActionOuterClass {
       }
       org.openmined.syftproto.execution.v1.CommunicationActionOuterClass.CommunicationAction other = (org.openmined.syftproto.execution.v1.CommunicationActionOuterClass.CommunicationAction) obj;
 
-      if (!getName()
-          .equals(other.getName())) return false;
-      if (hasObjId() != other.hasObjId()) return false;
-      if (hasObjId()) {
-        if (!getObjId()
-            .equals(other.getObjId())) return false;
-      }
-      if (hasSource() != other.hasSource()) return false;
-      if (hasSource()) {
-        if (!getSource()
-            .equals(other.getSource())) return false;
-      }
-      if (!getDestinationsList()
-          .equals(other.getDestinationsList())) return false;
+      if (!getCommand()
+          .equals(other.getCommand())) return false;
+      if (!getArgsList()
+          .equals(other.getArgsList())) return false;
       if (!internalGetKwargs().equals(
           other.internalGetKwargs())) return false;
+      if (!getReturnIdsList()
+          .equals(other.getReturnIdsList())) return false;
+      if (!getReturnPlaceholderIdsList()
+          .equals(other.getReturnPlaceholderIdsList())) return false;
+      if (!getTargetCase().equals(other.getTargetCase())) return false;
+      switch (targetCase_) {
+        case 9:
+          if (!getTargetId()
+              .equals(other.getTargetId())) return false;
+          break;
+        case 2:
+          if (!getTargetPointer()
+              .equals(other.getTargetPointer())) return false;
+          break;
+        case 3:
+          if (!getTargetPlaceholderId()
+              .equals(other.getTargetPlaceholderId())) return false;
+          break;
+        case 4:
+          if (!getTargetTensor()
+              .equals(other.getTargetTensor())) return false;
+          break;
+        case 0:
+        default:
+      }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -568,23 +928,43 @@ public final class CommunicationActionOuterClass {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      hash = (37 * hash) + NAME_FIELD_NUMBER;
-      hash = (53 * hash) + getName().hashCode();
-      if (hasObjId()) {
-        hash = (37 * hash) + OBJ_ID_FIELD_NUMBER;
-        hash = (53 * hash) + getObjId().hashCode();
-      }
-      if (hasSource()) {
-        hash = (37 * hash) + SOURCE_FIELD_NUMBER;
-        hash = (53 * hash) + getSource().hashCode();
-      }
-      if (getDestinationsCount() > 0) {
-        hash = (37 * hash) + DESTINATIONS_FIELD_NUMBER;
-        hash = (53 * hash) + getDestinationsList().hashCode();
+      hash = (37 * hash) + COMMAND_FIELD_NUMBER;
+      hash = (53 * hash) + getCommand().hashCode();
+      if (getArgsCount() > 0) {
+        hash = (37 * hash) + ARGS_FIELD_NUMBER;
+        hash = (53 * hash) + getArgsList().hashCode();
       }
       if (!internalGetKwargs().getMap().isEmpty()) {
         hash = (37 * hash) + KWARGS_FIELD_NUMBER;
         hash = (53 * hash) + internalGetKwargs().hashCode();
+      }
+      if (getReturnIdsCount() > 0) {
+        hash = (37 * hash) + RETURN_IDS_FIELD_NUMBER;
+        hash = (53 * hash) + getReturnIdsList().hashCode();
+      }
+      if (getReturnPlaceholderIdsCount() > 0) {
+        hash = (37 * hash) + RETURN_PLACEHOLDER_IDS_FIELD_NUMBER;
+        hash = (53 * hash) + getReturnPlaceholderIdsList().hashCode();
+      }
+      switch (targetCase_) {
+        case 9:
+          hash = (37 * hash) + TARGET_ID_FIELD_NUMBER;
+          hash = (53 * hash) + getTargetId().hashCode();
+          break;
+        case 2:
+          hash = (37 * hash) + TARGET_POINTER_FIELD_NUMBER;
+          hash = (53 * hash) + getTargetPointer().hashCode();
+          break;
+        case 3:
+          hash = (37 * hash) + TARGET_PLACEHOLDER_ID_FIELD_NUMBER;
+          hash = (53 * hash) + getTargetPlaceholderId().hashCode();
+          break;
+        case 4:
+          hash = (37 * hash) + TARGET_TENSOR_FIELD_NUMBER;
+          hash = (53 * hash) + getTargetTensor().hashCode();
+          break;
+        case 0:
+        default:
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -697,7 +1077,7 @@ public final class CommunicationActionOuterClass {
       protected com.google.protobuf.MapField internalGetMapField(
           int number) {
         switch (number) {
-          case 5:
+          case 6:
             return internalGetKwargs();
           default:
             throw new RuntimeException(
@@ -708,7 +1088,7 @@ public final class CommunicationActionOuterClass {
       protected com.google.protobuf.MapField internalGetMutableMapField(
           int number) {
         switch (number) {
-          case 5:
+          case 6:
             return internalGetMutableKwargs();
           default:
             throw new RuntimeException(
@@ -736,33 +1116,37 @@ public final class CommunicationActionOuterClass {
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessageV3
                 .alwaysUseFieldBuilders) {
-          getDestinationsFieldBuilder();
+          getArgsFieldBuilder();
+          getReturnIdsFieldBuilder();
+          getReturnPlaceholderIdsFieldBuilder();
         }
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        name_ = "";
+        command_ = "";
 
-        if (objIdBuilder_ == null) {
-          objId_ = null;
-        } else {
-          objId_ = null;
-          objIdBuilder_ = null;
-        }
-        if (sourceBuilder_ == null) {
-          source_ = null;
-        } else {
-          source_ = null;
-          sourceBuilder_ = null;
-        }
-        if (destinationsBuilder_ == null) {
-          destinations_ = java.util.Collections.emptyList();
+        if (argsBuilder_ == null) {
+          args_ = java.util.Collections.emptyList();
           bitField0_ = (bitField0_ & ~0x00000001);
         } else {
-          destinationsBuilder_.clear();
+          argsBuilder_.clear();
         }
         internalGetMutableKwargs().clear();
+        if (returnIdsBuilder_ == null) {
+          returnIds_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+        } else {
+          returnIdsBuilder_.clear();
+        }
+        if (returnPlaceholderIdsBuilder_ == null) {
+          returnPlaceholderIds_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000008);
+        } else {
+          returnPlaceholderIdsBuilder_.clear();
+        }
+        targetCase_ = 0;
+        target_ = null;
         return this;
       }
 
@@ -790,28 +1174,65 @@ public final class CommunicationActionOuterClass {
       public org.openmined.syftproto.execution.v1.CommunicationActionOuterClass.CommunicationAction buildPartial() {
         org.openmined.syftproto.execution.v1.CommunicationActionOuterClass.CommunicationAction result = new org.openmined.syftproto.execution.v1.CommunicationActionOuterClass.CommunicationAction(this);
         int from_bitField0_ = bitField0_;
-        result.name_ = name_;
-        if (objIdBuilder_ == null) {
-          result.objId_ = objId_;
-        } else {
-          result.objId_ = objIdBuilder_.build();
+        result.command_ = command_;
+        if (targetCase_ == 9) {
+          if (targetIdBuilder_ == null) {
+            result.target_ = target_;
+          } else {
+            result.target_ = targetIdBuilder_.build();
+          }
         }
-        if (sourceBuilder_ == null) {
-          result.source_ = source_;
-        } else {
-          result.source_ = sourceBuilder_.build();
+        if (targetCase_ == 2) {
+          if (targetPointerBuilder_ == null) {
+            result.target_ = target_;
+          } else {
+            result.target_ = targetPointerBuilder_.build();
+          }
         }
-        if (destinationsBuilder_ == null) {
+        if (targetCase_ == 3) {
+          if (targetPlaceholderIdBuilder_ == null) {
+            result.target_ = target_;
+          } else {
+            result.target_ = targetPlaceholderIdBuilder_.build();
+          }
+        }
+        if (targetCase_ == 4) {
+          if (targetTensorBuilder_ == null) {
+            result.target_ = target_;
+          } else {
+            result.target_ = targetTensorBuilder_.build();
+          }
+        }
+        if (argsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
-            destinations_ = java.util.Collections.unmodifiableList(destinations_);
+            args_ = java.util.Collections.unmodifiableList(args_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
-          result.destinations_ = destinations_;
+          result.args_ = args_;
         } else {
-          result.destinations_ = destinationsBuilder_.build();
+          result.args_ = argsBuilder_.build();
         }
         result.kwargs_ = internalGetKwargs();
         result.kwargs_.makeImmutable();
+        if (returnIdsBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) != 0)) {
+            returnIds_ = java.util.Collections.unmodifiableList(returnIds_);
+            bitField0_ = (bitField0_ & ~0x00000004);
+          }
+          result.returnIds_ = returnIds_;
+        } else {
+          result.returnIds_ = returnIdsBuilder_.build();
+        }
+        if (returnPlaceholderIdsBuilder_ == null) {
+          if (((bitField0_ & 0x00000008) != 0)) {
+            returnPlaceholderIds_ = java.util.Collections.unmodifiableList(returnPlaceholderIds_);
+            bitField0_ = (bitField0_ & ~0x00000008);
+          }
+          result.returnPlaceholderIds_ = returnPlaceholderIds_;
+        } else {
+          result.returnPlaceholderIds_ = returnPlaceholderIdsBuilder_.build();
+        }
+        result.targetCase_ = targetCase_;
         onBuilt();
         return result;
       }
@@ -860,44 +1281,111 @@ public final class CommunicationActionOuterClass {
 
       public Builder mergeFrom(org.openmined.syftproto.execution.v1.CommunicationActionOuterClass.CommunicationAction other) {
         if (other == org.openmined.syftproto.execution.v1.CommunicationActionOuterClass.CommunicationAction.getDefaultInstance()) return this;
-        if (!other.getName().isEmpty()) {
-          name_ = other.name_;
+        if (!other.getCommand().isEmpty()) {
+          command_ = other.command_;
           onChanged();
         }
-        if (other.hasObjId()) {
-          mergeObjId(other.getObjId());
-        }
-        if (other.hasSource()) {
-          mergeSource(other.getSource());
-        }
-        if (destinationsBuilder_ == null) {
-          if (!other.destinations_.isEmpty()) {
-            if (destinations_.isEmpty()) {
-              destinations_ = other.destinations_;
+        if (argsBuilder_ == null) {
+          if (!other.args_.isEmpty()) {
+            if (args_.isEmpty()) {
+              args_ = other.args_;
               bitField0_ = (bitField0_ & ~0x00000001);
             } else {
-              ensureDestinationsIsMutable();
-              destinations_.addAll(other.destinations_);
+              ensureArgsIsMutable();
+              args_.addAll(other.args_);
             }
             onChanged();
           }
         } else {
-          if (!other.destinations_.isEmpty()) {
-            if (destinationsBuilder_.isEmpty()) {
-              destinationsBuilder_.dispose();
-              destinationsBuilder_ = null;
-              destinations_ = other.destinations_;
+          if (!other.args_.isEmpty()) {
+            if (argsBuilder_.isEmpty()) {
+              argsBuilder_.dispose();
+              argsBuilder_ = null;
+              args_ = other.args_;
               bitField0_ = (bitField0_ & ~0x00000001);
-              destinationsBuilder_ = 
+              argsBuilder_ = 
                 com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                   getDestinationsFieldBuilder() : null;
+                   getArgsFieldBuilder() : null;
             } else {
-              destinationsBuilder_.addAllMessages(other.destinations_);
+              argsBuilder_.addAllMessages(other.args_);
             }
           }
         }
         internalGetMutableKwargs().mergeFrom(
             other.internalGetKwargs());
+        if (returnIdsBuilder_ == null) {
+          if (!other.returnIds_.isEmpty()) {
+            if (returnIds_.isEmpty()) {
+              returnIds_ = other.returnIds_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+            } else {
+              ensureReturnIdsIsMutable();
+              returnIds_.addAll(other.returnIds_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.returnIds_.isEmpty()) {
+            if (returnIdsBuilder_.isEmpty()) {
+              returnIdsBuilder_.dispose();
+              returnIdsBuilder_ = null;
+              returnIds_ = other.returnIds_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+              returnIdsBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getReturnIdsFieldBuilder() : null;
+            } else {
+              returnIdsBuilder_.addAllMessages(other.returnIds_);
+            }
+          }
+        }
+        if (returnPlaceholderIdsBuilder_ == null) {
+          if (!other.returnPlaceholderIds_.isEmpty()) {
+            if (returnPlaceholderIds_.isEmpty()) {
+              returnPlaceholderIds_ = other.returnPlaceholderIds_;
+              bitField0_ = (bitField0_ & ~0x00000008);
+            } else {
+              ensureReturnPlaceholderIdsIsMutable();
+              returnPlaceholderIds_.addAll(other.returnPlaceholderIds_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.returnPlaceholderIds_.isEmpty()) {
+            if (returnPlaceholderIdsBuilder_.isEmpty()) {
+              returnPlaceholderIdsBuilder_.dispose();
+              returnPlaceholderIdsBuilder_ = null;
+              returnPlaceholderIds_ = other.returnPlaceholderIds_;
+              bitField0_ = (bitField0_ & ~0x00000008);
+              returnPlaceholderIdsBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getReturnPlaceholderIdsFieldBuilder() : null;
+            } else {
+              returnPlaceholderIdsBuilder_.addAllMessages(other.returnPlaceholderIds_);
+            }
+          }
+        }
+        switch (other.getTargetCase()) {
+          case TARGET_ID: {
+            mergeTargetId(other.getTargetId());
+            break;
+          }
+          case TARGET_POINTER: {
+            mergeTargetPointer(other.getTargetPointer());
+            break;
+          }
+          case TARGET_PLACEHOLDER_ID: {
+            mergeTargetPlaceholderId(other.getTargetPlaceholderId());
+            break;
+          }
+          case TARGET_TENSOR: {
+            mergeTargetTensor(other.getTargetTensor());
+            break;
+          }
+          case TARGET_NOT_SET: {
+            break;
+          }
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -926,560 +1414,889 @@ public final class CommunicationActionOuterClass {
         }
         return this;
       }
+      private int targetCase_ = 0;
+      private java.lang.Object target_;
+      public TargetCase
+          getTargetCase() {
+        return TargetCase.forNumber(
+            targetCase_);
+      }
+
+      public Builder clearTarget() {
+        targetCase_ = 0;
+        target_ = null;
+        onChanged();
+        return this;
+      }
+
       private int bitField0_;
 
-      private java.lang.Object name_ = "";
+      private java.lang.Object command_ = "";
       /**
-       * <code>string name = 1[json_name = "name"];</code>
-       * @return The name.
+       * <code>string command = 1[json_name = "command"];</code>
+       * @return The command.
        */
-      public java.lang.String getName() {
-        java.lang.Object ref = name_;
+      public java.lang.String getCommand() {
+        java.lang.Object ref = command_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
-          name_ = s;
+          command_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
         }
       }
       /**
-       * <code>string name = 1[json_name = "name"];</code>
-       * @return The bytes for name.
+       * <code>string command = 1[json_name = "command"];</code>
+       * @return The bytes for command.
        */
       public com.google.protobuf.ByteString
-          getNameBytes() {
-        java.lang.Object ref = name_;
+          getCommandBytes() {
+        java.lang.Object ref = command_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
-          name_ = b;
+          command_ = b;
           return b;
         } else {
           return (com.google.protobuf.ByteString) ref;
         }
       }
       /**
-       * <code>string name = 1[json_name = "name"];</code>
-       * @param value The name to set.
+       * <code>string command = 1[json_name = "command"];</code>
+       * @param value The command to set.
        * @return This builder for chaining.
        */
-      public Builder setName(
+      public Builder setCommand(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
   
-        name_ = value;
+        command_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>string name = 1[json_name = "name"];</code>
+       * <code>string command = 1[json_name = "command"];</code>
        * @return This builder for chaining.
        */
-      public Builder clearName() {
+      public Builder clearCommand() {
         
-        name_ = getDefaultInstance().getName();
+        command_ = getDefaultInstance().getCommand();
         onChanged();
         return this;
       }
       /**
-       * <code>string name = 1[json_name = "name"];</code>
-       * @param value The bytes for name to set.
+       * <code>string command = 1[json_name = "command"];</code>
+       * @param value The bytes for command to set.
        * @return This builder for chaining.
        */
-      public Builder setNameBytes(
+      public Builder setCommandBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
   checkByteStringIsUtf8(value);
         
-        name_ = value;
+        command_ = value;
         onChanged();
         return this;
       }
 
-      private org.openmined.syftproto.types.syft.v1.IdOuterClass.Id objId_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> objIdBuilder_;
+          org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> targetIdBuilder_;
       /**
-       * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
-       * @return Whether the objId field is set.
+       * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
+       * @return Whether the targetId field is set.
        */
-      public boolean hasObjId() {
-        return objIdBuilder_ != null || objId_ != null;
+      public boolean hasTargetId() {
+        return targetCase_ == 9;
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
-       * @return The objId.
+       * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
+       * @return The targetId.
        */
-      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getObjId() {
-        if (objIdBuilder_ == null) {
-          return objId_ == null ? org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance() : objId_;
+      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getTargetId() {
+        if (targetIdBuilder_ == null) {
+          if (targetCase_ == 9) {
+            return (org.openmined.syftproto.types.syft.v1.IdOuterClass.Id) target_;
+          }
+          return org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance();
         } else {
-          return objIdBuilder_.getMessage();
+          if (targetCase_ == 9) {
+            return targetIdBuilder_.getMessage();
+          }
+          return org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance();
         }
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
+       * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
        */
-      public Builder setObjId(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
-        if (objIdBuilder_ == null) {
+      public Builder setTargetId(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
+        if (targetIdBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          objId_ = value;
+          target_ = value;
           onChanged();
         } else {
-          objIdBuilder_.setMessage(value);
+          targetIdBuilder_.setMessage(value);
         }
-
+        targetCase_ = 9;
         return this;
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
+       * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
        */
-      public Builder setObjId(
+      public Builder setTargetId(
           org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder builderForValue) {
-        if (objIdBuilder_ == null) {
-          objId_ = builderForValue.build();
+        if (targetIdBuilder_ == null) {
+          target_ = builderForValue.build();
           onChanged();
         } else {
-          objIdBuilder_.setMessage(builderForValue.build());
+          targetIdBuilder_.setMessage(builderForValue.build());
         }
-
+        targetCase_ = 9;
         return this;
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
+       * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
        */
-      public Builder mergeObjId(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
-        if (objIdBuilder_ == null) {
-          if (objId_ != null) {
-            objId_ =
-              org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.newBuilder(objId_).mergeFrom(value).buildPartial();
+      public Builder mergeTargetId(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
+        if (targetIdBuilder_ == null) {
+          if (targetCase_ == 9 &&
+              target_ != org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance()) {
+            target_ = org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.newBuilder((org.openmined.syftproto.types.syft.v1.IdOuterClass.Id) target_)
+                .mergeFrom(value).buildPartial();
           } else {
-            objId_ = value;
+            target_ = value;
           }
           onChanged();
         } else {
-          objIdBuilder_.mergeFrom(value);
+          if (targetCase_ == 9) {
+            targetIdBuilder_.mergeFrom(value);
+          }
+          targetIdBuilder_.setMessage(value);
         }
-
+        targetCase_ = 9;
         return this;
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
+       * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
        */
-      public Builder clearObjId() {
-        if (objIdBuilder_ == null) {
-          objId_ = null;
-          onChanged();
+      public Builder clearTargetId() {
+        if (targetIdBuilder_ == null) {
+          if (targetCase_ == 9) {
+            targetCase_ = 0;
+            target_ = null;
+            onChanged();
+          }
         } else {
-          objId_ = null;
-          objIdBuilder_ = null;
+          if (targetCase_ == 9) {
+            targetCase_ = 0;
+            target_ = null;
+          }
+          targetIdBuilder_.clear();
         }
-
         return this;
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
+       * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
        */
-      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder getObjIdBuilder() {
-        
-        onChanged();
-        return getObjIdFieldBuilder().getBuilder();
+      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder getTargetIdBuilder() {
+        return getTargetIdFieldBuilder().getBuilder();
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
+       * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
        */
-      public org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getObjIdOrBuilder() {
-        if (objIdBuilder_ != null) {
-          return objIdBuilder_.getMessageOrBuilder();
+      public org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getTargetIdOrBuilder() {
+        if ((targetCase_ == 9) && (targetIdBuilder_ != null)) {
+          return targetIdBuilder_.getMessageOrBuilder();
         } else {
-          return objId_ == null ?
-              org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance() : objId_;
+          if (targetCase_ == 9) {
+            return (org.openmined.syftproto.types.syft.v1.IdOuterClass.Id) target_;
+          }
+          return org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance();
         }
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id obj_id = 2[json_name = "objId"];</code>
+       * <code>.syft_proto.types.syft.v1.Id target_id = 9[json_name = "targetId"];</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> 
-          getObjIdFieldBuilder() {
-        if (objIdBuilder_ == null) {
-          objIdBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+          getTargetIdFieldBuilder() {
+        if (targetIdBuilder_ == null) {
+          if (!(targetCase_ == 9)) {
+            target_ = org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance();
+          }
+          targetIdBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder>(
-                  getObjId(),
+                  (org.openmined.syftproto.types.syft.v1.IdOuterClass.Id) target_,
                   getParentForChildren(),
                   isClean());
-          objId_ = null;
+          target_ = null;
         }
-        return objIdBuilder_;
+        targetCase_ = 9;
+        onChanged();;
+        return targetIdBuilder_;
       }
 
-      private org.openmined.syftproto.types.syft.v1.IdOuterClass.Id source_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> sourceBuilder_;
+          org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor, org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.Builder, org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensorOrBuilder> targetPointerBuilder_;
       /**
-       * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
-       * @return Whether the source field is set.
+       * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
+       * @return Whether the targetPointer field is set.
        */
-      public boolean hasSource() {
-        return sourceBuilder_ != null || source_ != null;
+      public boolean hasTargetPointer() {
+        return targetCase_ == 2;
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
-       * @return The source.
+       * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
+       * @return The targetPointer.
        */
-      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getSource() {
-        if (sourceBuilder_ == null) {
-          return source_ == null ? org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance() : source_;
+      public org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor getTargetPointer() {
+        if (targetPointerBuilder_ == null) {
+          if (targetCase_ == 2) {
+            return (org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor) target_;
+          }
+          return org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.getDefaultInstance();
         } else {
-          return sourceBuilder_.getMessage();
+          if (targetCase_ == 2) {
+            return targetPointerBuilder_.getMessage();
+          }
+          return org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.getDefaultInstance();
         }
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
+       * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
        */
-      public Builder setSource(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
-        if (sourceBuilder_ == null) {
+      public Builder setTargetPointer(org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor value) {
+        if (targetPointerBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          source_ = value;
+          target_ = value;
           onChanged();
         } else {
-          sourceBuilder_.setMessage(value);
+          targetPointerBuilder_.setMessage(value);
         }
-
+        targetCase_ = 2;
         return this;
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
+       * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
        */
-      public Builder setSource(
-          org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder builderForValue) {
-        if (sourceBuilder_ == null) {
-          source_ = builderForValue.build();
+      public Builder setTargetPointer(
+          org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.Builder builderForValue) {
+        if (targetPointerBuilder_ == null) {
+          target_ = builderForValue.build();
           onChanged();
         } else {
-          sourceBuilder_.setMessage(builderForValue.build());
+          targetPointerBuilder_.setMessage(builderForValue.build());
         }
-
+        targetCase_ = 2;
         return this;
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
+       * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
        */
-      public Builder mergeSource(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
-        if (sourceBuilder_ == null) {
-          if (source_ != null) {
-            source_ =
-              org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.newBuilder(source_).mergeFrom(value).buildPartial();
+      public Builder mergeTargetPointer(org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor value) {
+        if (targetPointerBuilder_ == null) {
+          if (targetCase_ == 2 &&
+              target_ != org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.getDefaultInstance()) {
+            target_ = org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.newBuilder((org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor) target_)
+                .mergeFrom(value).buildPartial();
           } else {
-            source_ = value;
+            target_ = value;
           }
           onChanged();
         } else {
-          sourceBuilder_.mergeFrom(value);
+          if (targetCase_ == 2) {
+            targetPointerBuilder_.mergeFrom(value);
+          }
+          targetPointerBuilder_.setMessage(value);
         }
-
+        targetCase_ = 2;
         return this;
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
+       * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
        */
-      public Builder clearSource() {
-        if (sourceBuilder_ == null) {
-          source_ = null;
-          onChanged();
+      public Builder clearTargetPointer() {
+        if (targetPointerBuilder_ == null) {
+          if (targetCase_ == 2) {
+            targetCase_ = 0;
+            target_ = null;
+            onChanged();
+          }
         } else {
-          source_ = null;
-          sourceBuilder_ = null;
+          if (targetCase_ == 2) {
+            targetCase_ = 0;
+            target_ = null;
+          }
+          targetPointerBuilder_.clear();
         }
-
         return this;
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
+       * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
        */
-      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder getSourceBuilder() {
-        
-        onChanged();
-        return getSourceFieldBuilder().getBuilder();
+      public org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.Builder getTargetPointerBuilder() {
+        return getTargetPointerFieldBuilder().getBuilder();
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
+       * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
        */
-      public org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getSourceOrBuilder() {
-        if (sourceBuilder_ != null) {
-          return sourceBuilder_.getMessageOrBuilder();
+      public org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensorOrBuilder getTargetPointerOrBuilder() {
+        if ((targetCase_ == 2) && (targetPointerBuilder_ != null)) {
+          return targetPointerBuilder_.getMessageOrBuilder();
         } else {
-          return source_ == null ?
-              org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance() : source_;
+          if (targetCase_ == 2) {
+            return (org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor) target_;
+          }
+          return org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.getDefaultInstance();
         }
       }
       /**
-       * <code>.syft_proto.types.syft.v1.Id source = 3[json_name = "source"];</code>
+       * <code>.syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2[json_name = "targetPointer"];</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> 
-          getSourceFieldBuilder() {
-        if (sourceBuilder_ == null) {
-          sourceBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder>(
-                  getSource(),
+          org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor, org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.Builder, org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensorOrBuilder> 
+          getTargetPointerFieldBuilder() {
+        if (targetPointerBuilder_ == null) {
+          if (!(targetCase_ == 2)) {
+            target_ = org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.getDefaultInstance();
+          }
+          targetPointerBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor, org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor.Builder, org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensorOrBuilder>(
+                  (org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.PointerTensor) target_,
                   getParentForChildren(),
                   isClean());
-          source_ = null;
+          target_ = null;
         }
-        return sourceBuilder_;
+        targetCase_ = 2;
+        onChanged();;
+        return targetPointerBuilder_;
       }
 
-      private java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> destinations_ =
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder> targetPlaceholderIdBuilder_;
+      /**
+       * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+       * @return Whether the targetPlaceholderId field is set.
+       */
+      public boolean hasTargetPlaceholderId() {
+        return targetCase_ == 3;
+      }
+      /**
+       * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+       * @return The targetPlaceholderId.
+       */
+      public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId getTargetPlaceholderId() {
+        if (targetPlaceholderIdBuilder_ == null) {
+          if (targetCase_ == 3) {
+            return (org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId) target_;
+          }
+          return org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.getDefaultInstance();
+        } else {
+          if (targetCase_ == 3) {
+            return targetPlaceholderIdBuilder_.getMessage();
+          }
+          return org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+       */
+      public Builder setTargetPlaceholderId(org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId value) {
+        if (targetPlaceholderIdBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          target_ = value;
+          onChanged();
+        } else {
+          targetPlaceholderIdBuilder_.setMessage(value);
+        }
+        targetCase_ = 3;
+        return this;
+      }
+      /**
+       * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+       */
+      public Builder setTargetPlaceholderId(
+          org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder builderForValue) {
+        if (targetPlaceholderIdBuilder_ == null) {
+          target_ = builderForValue.build();
+          onChanged();
+        } else {
+          targetPlaceholderIdBuilder_.setMessage(builderForValue.build());
+        }
+        targetCase_ = 3;
+        return this;
+      }
+      /**
+       * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+       */
+      public Builder mergeTargetPlaceholderId(org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId value) {
+        if (targetPlaceholderIdBuilder_ == null) {
+          if (targetCase_ == 3 &&
+              target_ != org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.getDefaultInstance()) {
+            target_ = org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.newBuilder((org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId) target_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            target_ = value;
+          }
+          onChanged();
+        } else {
+          if (targetCase_ == 3) {
+            targetPlaceholderIdBuilder_.mergeFrom(value);
+          }
+          targetPlaceholderIdBuilder_.setMessage(value);
+        }
+        targetCase_ = 3;
+        return this;
+      }
+      /**
+       * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+       */
+      public Builder clearTargetPlaceholderId() {
+        if (targetPlaceholderIdBuilder_ == null) {
+          if (targetCase_ == 3) {
+            targetCase_ = 0;
+            target_ = null;
+            onChanged();
+          }
+        } else {
+          if (targetCase_ == 3) {
+            targetCase_ = 0;
+            target_ = null;
+          }
+          targetPlaceholderIdBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+       */
+      public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder getTargetPlaceholderIdBuilder() {
+        return getTargetPlaceholderIdFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+       */
+      public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder getTargetPlaceholderIdOrBuilder() {
+        if ((targetCase_ == 3) && (targetPlaceholderIdBuilder_ != null)) {
+          return targetPlaceholderIdBuilder_.getMessageOrBuilder();
+        } else {
+          if (targetCase_ == 3) {
+            return (org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId) target_;
+          }
+          return org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3[json_name = "targetPlaceholderId"];</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder> 
+          getTargetPlaceholderIdFieldBuilder() {
+        if (targetPlaceholderIdBuilder_ == null) {
+          if (!(targetCase_ == 3)) {
+            target_ = org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.getDefaultInstance();
+          }
+          targetPlaceholderIdBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder>(
+                  (org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId) target_,
+                  getParentForChildren(),
+                  isClean());
+          target_ = null;
+        }
+        targetCase_ = 3;
+        onChanged();;
+        return targetPlaceholderIdBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor, org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.Builder, org.openmined.syftproto.types.torch.v1.Tensor.TorchTensorOrBuilder> targetTensorBuilder_;
+      /**
+       * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+       * @return Whether the targetTensor field is set.
+       */
+      public boolean hasTargetTensor() {
+        return targetCase_ == 4;
+      }
+      /**
+       * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+       * @return The targetTensor.
+       */
+      public org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor getTargetTensor() {
+        if (targetTensorBuilder_ == null) {
+          if (targetCase_ == 4) {
+            return (org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor) target_;
+          }
+          return org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.getDefaultInstance();
+        } else {
+          if (targetCase_ == 4) {
+            return targetTensorBuilder_.getMessage();
+          }
+          return org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+       */
+      public Builder setTargetTensor(org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor value) {
+        if (targetTensorBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          target_ = value;
+          onChanged();
+        } else {
+          targetTensorBuilder_.setMessage(value);
+        }
+        targetCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+       */
+      public Builder setTargetTensor(
+          org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.Builder builderForValue) {
+        if (targetTensorBuilder_ == null) {
+          target_ = builderForValue.build();
+          onChanged();
+        } else {
+          targetTensorBuilder_.setMessage(builderForValue.build());
+        }
+        targetCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+       */
+      public Builder mergeTargetTensor(org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor value) {
+        if (targetTensorBuilder_ == null) {
+          if (targetCase_ == 4 &&
+              target_ != org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.getDefaultInstance()) {
+            target_ = org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.newBuilder((org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor) target_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            target_ = value;
+          }
+          onChanged();
+        } else {
+          if (targetCase_ == 4) {
+            targetTensorBuilder_.mergeFrom(value);
+          }
+          targetTensorBuilder_.setMessage(value);
+        }
+        targetCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+       */
+      public Builder clearTargetTensor() {
+        if (targetTensorBuilder_ == null) {
+          if (targetCase_ == 4) {
+            targetCase_ = 0;
+            target_ = null;
+            onChanged();
+          }
+        } else {
+          if (targetCase_ == 4) {
+            targetCase_ = 0;
+            target_ = null;
+          }
+          targetTensorBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+       */
+      public org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.Builder getTargetTensorBuilder() {
+        return getTargetTensorFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+       */
+      public org.openmined.syftproto.types.torch.v1.Tensor.TorchTensorOrBuilder getTargetTensorOrBuilder() {
+        if ((targetCase_ == 4) && (targetTensorBuilder_ != null)) {
+          return targetTensorBuilder_.getMessageOrBuilder();
+        } else {
+          if (targetCase_ == 4) {
+            return (org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor) target_;
+          }
+          return org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.syft_proto.types.torch.v1.TorchTensor target_tensor = 4[json_name = "targetTensor"];</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor, org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.Builder, org.openmined.syftproto.types.torch.v1.Tensor.TorchTensorOrBuilder> 
+          getTargetTensorFieldBuilder() {
+        if (targetTensorBuilder_ == null) {
+          if (!(targetCase_ == 4)) {
+            target_ = org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.getDefaultInstance();
+          }
+          targetTensorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor, org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor.Builder, org.openmined.syftproto.types.torch.v1.Tensor.TorchTensorOrBuilder>(
+                  (org.openmined.syftproto.types.torch.v1.Tensor.TorchTensor) target_,
+                  getParentForChildren(),
+                  isClean());
+          target_ = null;
+        }
+        targetCase_ = 4;
+        onChanged();;
+        return targetTensorBuilder_;
+      }
+
+      private java.util.List<org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg> args_ =
         java.util.Collections.emptyList();
-      private void ensureDestinationsIsMutable() {
+      private void ensureArgsIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          destinations_ = new java.util.ArrayList<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id>(destinations_);
+          args_ = new java.util.ArrayList<org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg>(args_);
           bitField0_ |= 0x00000001;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> destinationsBuilder_;
+          org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.Builder, org.openmined.syftproto.types.syft.v1.ArgOuterClass.ArgOrBuilder> argsBuilder_;
 
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> getDestinationsList() {
-        if (destinationsBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(destinations_);
+      public java.util.List<org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg> getArgsList() {
+        if (argsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(args_);
         } else {
-          return destinationsBuilder_.getMessageList();
+          return argsBuilder_.getMessageList();
         }
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public int getDestinationsCount() {
-        if (destinationsBuilder_ == null) {
-          return destinations_.size();
+      public int getArgsCount() {
+        if (argsBuilder_ == null) {
+          return args_.size();
         } else {
-          return destinationsBuilder_.getCount();
+          return argsBuilder_.getCount();
         }
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getDestinations(int index) {
-        if (destinationsBuilder_ == null) {
-          return destinations_.get(index);
+      public org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg getArgs(int index) {
+        if (argsBuilder_ == null) {
+          return args_.get(index);
         } else {
-          return destinationsBuilder_.getMessage(index);
+          return argsBuilder_.getMessage(index);
         }
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public Builder setDestinations(
-          int index, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
-        if (destinationsBuilder_ == null) {
+      public Builder setArgs(
+          int index, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg value) {
+        if (argsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureDestinationsIsMutable();
-          destinations_.set(index, value);
+          ensureArgsIsMutable();
+          args_.set(index, value);
           onChanged();
         } else {
-          destinationsBuilder_.setMessage(index, value);
+          argsBuilder_.setMessage(index, value);
         }
         return this;
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public Builder setDestinations(
-          int index, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder builderForValue) {
-        if (destinationsBuilder_ == null) {
-          ensureDestinationsIsMutable();
-          destinations_.set(index, builderForValue.build());
+      public Builder setArgs(
+          int index, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.Builder builderForValue) {
+        if (argsBuilder_ == null) {
+          ensureArgsIsMutable();
+          args_.set(index, builderForValue.build());
           onChanged();
         } else {
-          destinationsBuilder_.setMessage(index, builderForValue.build());
+          argsBuilder_.setMessage(index, builderForValue.build());
         }
         return this;
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public Builder addDestinations(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
-        if (destinationsBuilder_ == null) {
+      public Builder addArgs(org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg value) {
+        if (argsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureDestinationsIsMutable();
-          destinations_.add(value);
+          ensureArgsIsMutable();
+          args_.add(value);
           onChanged();
         } else {
-          destinationsBuilder_.addMessage(value);
+          argsBuilder_.addMessage(value);
         }
         return this;
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public Builder addDestinations(
-          int index, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
-        if (destinationsBuilder_ == null) {
+      public Builder addArgs(
+          int index, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg value) {
+        if (argsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureDestinationsIsMutable();
-          destinations_.add(index, value);
+          ensureArgsIsMutable();
+          args_.add(index, value);
           onChanged();
         } else {
-          destinationsBuilder_.addMessage(index, value);
+          argsBuilder_.addMessage(index, value);
         }
         return this;
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public Builder addDestinations(
-          org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder builderForValue) {
-        if (destinationsBuilder_ == null) {
-          ensureDestinationsIsMutable();
-          destinations_.add(builderForValue.build());
+      public Builder addArgs(
+          org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.Builder builderForValue) {
+        if (argsBuilder_ == null) {
+          ensureArgsIsMutable();
+          args_.add(builderForValue.build());
           onChanged();
         } else {
-          destinationsBuilder_.addMessage(builderForValue.build());
+          argsBuilder_.addMessage(builderForValue.build());
         }
         return this;
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public Builder addDestinations(
-          int index, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder builderForValue) {
-        if (destinationsBuilder_ == null) {
-          ensureDestinationsIsMutable();
-          destinations_.add(index, builderForValue.build());
+      public Builder addArgs(
+          int index, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.Builder builderForValue) {
+        if (argsBuilder_ == null) {
+          ensureArgsIsMutable();
+          args_.add(index, builderForValue.build());
           onChanged();
         } else {
-          destinationsBuilder_.addMessage(index, builderForValue.build());
+          argsBuilder_.addMessage(index, builderForValue.build());
         }
         return this;
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public Builder addAllDestinations(
-          java.lang.Iterable<? extends org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> values) {
-        if (destinationsBuilder_ == null) {
-          ensureDestinationsIsMutable();
+      public Builder addAllArgs(
+          java.lang.Iterable<? extends org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg> values) {
+        if (argsBuilder_ == null) {
+          ensureArgsIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, destinations_);
+              values, args_);
           onChanged();
         } else {
-          destinationsBuilder_.addAllMessages(values);
+          argsBuilder_.addAllMessages(values);
         }
         return this;
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public Builder clearDestinations() {
-        if (destinationsBuilder_ == null) {
-          destinations_ = java.util.Collections.emptyList();
+      public Builder clearArgs() {
+        if (argsBuilder_ == null) {
+          args_ = java.util.Collections.emptyList();
           bitField0_ = (bitField0_ & ~0x00000001);
           onChanged();
         } else {
-          destinationsBuilder_.clear();
+          argsBuilder_.clear();
         }
         return this;
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public Builder removeDestinations(int index) {
-        if (destinationsBuilder_ == null) {
-          ensureDestinationsIsMutable();
-          destinations_.remove(index);
+      public Builder removeArgs(int index) {
+        if (argsBuilder_ == null) {
+          ensureArgsIsMutable();
+          args_.remove(index);
           onChanged();
         } else {
-          destinationsBuilder_.remove(index);
+          argsBuilder_.remove(index);
         }
         return this;
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder getDestinationsBuilder(
+      public org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.Builder getArgsBuilder(
           int index) {
-        return getDestinationsFieldBuilder().getBuilder(index);
+        return getArgsFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getDestinationsOrBuilder(
+      public org.openmined.syftproto.types.syft.v1.ArgOuterClass.ArgOrBuilder getArgsOrBuilder(
           int index) {
-        if (destinationsBuilder_ == null) {
-          return destinations_.get(index);  } else {
-          return destinationsBuilder_.getMessageOrBuilder(index);
+        if (argsBuilder_ == null) {
+          return args_.get(index);  } else {
+          return argsBuilder_.getMessageOrBuilder(index);
         }
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public java.util.List<? extends org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> 
-           getDestinationsOrBuilderList() {
-        if (destinationsBuilder_ != null) {
-          return destinationsBuilder_.getMessageOrBuilderList();
+      public java.util.List<? extends org.openmined.syftproto.types.syft.v1.ArgOuterClass.ArgOrBuilder> 
+           getArgsOrBuilderList() {
+        if (argsBuilder_ != null) {
+          return argsBuilder_.getMessageOrBuilderList();
         } else {
-          return java.util.Collections.unmodifiableList(destinations_);
+          return java.util.Collections.unmodifiableList(args_);
         }
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder addDestinationsBuilder() {
-        return getDestinationsFieldBuilder().addBuilder(
-            org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance());
+      public org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.Builder addArgsBuilder() {
+        return getArgsFieldBuilder().addBuilder(
+            org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.getDefaultInstance());
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder addDestinationsBuilder(
+      public org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.Builder addArgsBuilder(
           int index) {
-        return getDestinationsFieldBuilder().addBuilder(
-            index, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance());
+        return getArgsFieldBuilder().addBuilder(
+            index, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.getDefaultInstance());
       }
       /**
-       * <code>repeated .syft_proto.types.syft.v1.Id destinations = 4[json_name = "destinations"];</code>
+       * <code>repeated .syft_proto.types.syft.v1.Arg args = 5[json_name = "args"];</code>
        */
-      public java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder> 
-           getDestinationsBuilderList() {
-        return getDestinationsFieldBuilder().getBuilderList();
+      public java.util.List<org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.Builder> 
+           getArgsBuilderList() {
+        return getArgsFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> 
-          getDestinationsFieldBuilder() {
-        if (destinationsBuilder_ == null) {
-          destinationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder>(
-                  destinations_,
+          org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.Builder, org.openmined.syftproto.types.syft.v1.ArgOuterClass.ArgOrBuilder> 
+          getArgsFieldBuilder() {
+        if (argsBuilder_ == null) {
+          argsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg.Builder, org.openmined.syftproto.types.syft.v1.ArgOuterClass.ArgOrBuilder>(
+                  args_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
-          destinations_ = null;
+          args_ = null;
         }
-        return destinationsBuilder_;
+        return argsBuilder_;
       }
 
       private com.google.protobuf.MapField<
@@ -1509,7 +2326,7 @@ public final class CommunicationActionOuterClass {
         return internalGetKwargs().getMap().size();
       }
       /**
-       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
        */
 
       public boolean containsKwargs(
@@ -1525,14 +2342,14 @@ public final class CommunicationActionOuterClass {
         return getKwargsMap();
       }
       /**
-       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
        */
 
       public java.util.Map<java.lang.String, org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg> getKwargsMap() {
         return internalGetKwargs().getMap();
       }
       /**
-       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
        */
 
       public org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg getKwargsOrDefault(
@@ -1544,7 +2361,7 @@ public final class CommunicationActionOuterClass {
         return map.containsKey(key) ? map.get(key) : defaultValue;
       }
       /**
-       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
        */
 
       public org.openmined.syftproto.types.syft.v1.ArgOuterClass.Arg getKwargsOrThrow(
@@ -1564,7 +2381,7 @@ public final class CommunicationActionOuterClass {
         return this;
       }
       /**
-       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
        */
 
       public Builder removeKwargs(
@@ -1583,7 +2400,7 @@ public final class CommunicationActionOuterClass {
         return internalGetMutableKwargs().getMutableMap();
       }
       /**
-       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
        */
       public Builder putKwargs(
           java.lang.String key,
@@ -1595,7 +2412,7 @@ public final class CommunicationActionOuterClass {
         return this;
       }
       /**
-       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 5[json_name = "kwargs"];</code>
+       * <code>map&lt;string, .syft_proto.types.syft.v1.Arg&gt; kwargs = 6[json_name = "kwargs"];</code>
        */
 
       public Builder putAllKwargs(
@@ -1603,6 +2420,486 @@ public final class CommunicationActionOuterClass {
         internalGetMutableKwargs().getMutableMap()
             .putAll(values);
         return this;
+      }
+
+      private java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> returnIds_ =
+        java.util.Collections.emptyList();
+      private void ensureReturnIdsIsMutable() {
+        if (!((bitField0_ & 0x00000004) != 0)) {
+          returnIds_ = new java.util.ArrayList<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id>(returnIds_);
+          bitField0_ |= 0x00000004;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> returnIdsBuilder_;
+
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> getReturnIdsList() {
+        if (returnIdsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(returnIds_);
+        } else {
+          return returnIdsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public int getReturnIdsCount() {
+        if (returnIdsBuilder_ == null) {
+          return returnIds_.size();
+        } else {
+          return returnIdsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id getReturnIds(int index) {
+        if (returnIdsBuilder_ == null) {
+          return returnIds_.get(index);
+        } else {
+          return returnIdsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public Builder setReturnIds(
+          int index, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
+        if (returnIdsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureReturnIdsIsMutable();
+          returnIds_.set(index, value);
+          onChanged();
+        } else {
+          returnIdsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public Builder setReturnIds(
+          int index, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder builderForValue) {
+        if (returnIdsBuilder_ == null) {
+          ensureReturnIdsIsMutable();
+          returnIds_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          returnIdsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public Builder addReturnIds(org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
+        if (returnIdsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureReturnIdsIsMutable();
+          returnIds_.add(value);
+          onChanged();
+        } else {
+          returnIdsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public Builder addReturnIds(
+          int index, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id value) {
+        if (returnIdsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureReturnIdsIsMutable();
+          returnIds_.add(index, value);
+          onChanged();
+        } else {
+          returnIdsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public Builder addReturnIds(
+          org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder builderForValue) {
+        if (returnIdsBuilder_ == null) {
+          ensureReturnIdsIsMutable();
+          returnIds_.add(builderForValue.build());
+          onChanged();
+        } else {
+          returnIdsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public Builder addReturnIds(
+          int index, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder builderForValue) {
+        if (returnIdsBuilder_ == null) {
+          ensureReturnIdsIsMutable();
+          returnIds_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          returnIdsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public Builder addAllReturnIds(
+          java.lang.Iterable<? extends org.openmined.syftproto.types.syft.v1.IdOuterClass.Id> values) {
+        if (returnIdsBuilder_ == null) {
+          ensureReturnIdsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, returnIds_);
+          onChanged();
+        } else {
+          returnIdsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public Builder clearReturnIds() {
+        if (returnIdsBuilder_ == null) {
+          returnIds_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+          onChanged();
+        } else {
+          returnIdsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public Builder removeReturnIds(int index) {
+        if (returnIdsBuilder_ == null) {
+          ensureReturnIdsIsMutable();
+          returnIds_.remove(index);
+          onChanged();
+        } else {
+          returnIdsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder getReturnIdsBuilder(
+          int index) {
+        return getReturnIdsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder getReturnIdsOrBuilder(
+          int index) {
+        if (returnIdsBuilder_ == null) {
+          return returnIds_.get(index);  } else {
+          return returnIdsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public java.util.List<? extends org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> 
+           getReturnIdsOrBuilderList() {
+        if (returnIdsBuilder_ != null) {
+          return returnIdsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(returnIds_);
+        }
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder addReturnIdsBuilder() {
+        return getReturnIdsFieldBuilder().addBuilder(
+            org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder addReturnIdsBuilder(
+          int index) {
+        return getReturnIdsFieldBuilder().addBuilder(
+            index, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .syft_proto.types.syft.v1.Id return_ids = 7[json_name = "returnIds"];</code>
+       */
+      public java.util.List<org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder> 
+           getReturnIdsBuilderList() {
+        return getReturnIdsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder> 
+          getReturnIdsFieldBuilder() {
+        if (returnIdsBuilder_ == null) {
+          returnIdsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              org.openmined.syftproto.types.syft.v1.IdOuterClass.Id, org.openmined.syftproto.types.syft.v1.IdOuterClass.Id.Builder, org.openmined.syftproto.types.syft.v1.IdOuterClass.IdOrBuilder>(
+                  returnIds_,
+                  ((bitField0_ & 0x00000004) != 0),
+                  getParentForChildren(),
+                  isClean());
+          returnIds_ = null;
+        }
+        return returnIdsBuilder_;
+      }
+
+      private java.util.List<org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId> returnPlaceholderIds_ =
+        java.util.Collections.emptyList();
+      private void ensureReturnPlaceholderIdsIsMutable() {
+        if (!((bitField0_ & 0x00000008) != 0)) {
+          returnPlaceholderIds_ = new java.util.ArrayList<org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId>(returnPlaceholderIds_);
+          bitField0_ |= 0x00000008;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder> returnPlaceholderIdsBuilder_;
+
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public java.util.List<org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId> getReturnPlaceholderIdsList() {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(returnPlaceholderIds_);
+        } else {
+          return returnPlaceholderIdsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public int getReturnPlaceholderIdsCount() {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          return returnPlaceholderIds_.size();
+        } else {
+          return returnPlaceholderIdsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId getReturnPlaceholderIds(int index) {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          return returnPlaceholderIds_.get(index);
+        } else {
+          return returnPlaceholderIdsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public Builder setReturnPlaceholderIds(
+          int index, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId value) {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureReturnPlaceholderIdsIsMutable();
+          returnPlaceholderIds_.set(index, value);
+          onChanged();
+        } else {
+          returnPlaceholderIdsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public Builder setReturnPlaceholderIds(
+          int index, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder builderForValue) {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          ensureReturnPlaceholderIdsIsMutable();
+          returnPlaceholderIds_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          returnPlaceholderIdsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public Builder addReturnPlaceholderIds(org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId value) {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureReturnPlaceholderIdsIsMutable();
+          returnPlaceholderIds_.add(value);
+          onChanged();
+        } else {
+          returnPlaceholderIdsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public Builder addReturnPlaceholderIds(
+          int index, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId value) {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureReturnPlaceholderIdsIsMutable();
+          returnPlaceholderIds_.add(index, value);
+          onChanged();
+        } else {
+          returnPlaceholderIdsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public Builder addReturnPlaceholderIds(
+          org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder builderForValue) {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          ensureReturnPlaceholderIdsIsMutable();
+          returnPlaceholderIds_.add(builderForValue.build());
+          onChanged();
+        } else {
+          returnPlaceholderIdsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public Builder addReturnPlaceholderIds(
+          int index, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder builderForValue) {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          ensureReturnPlaceholderIdsIsMutable();
+          returnPlaceholderIds_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          returnPlaceholderIdsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public Builder addAllReturnPlaceholderIds(
+          java.lang.Iterable<? extends org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId> values) {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          ensureReturnPlaceholderIdsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, returnPlaceholderIds_);
+          onChanged();
+        } else {
+          returnPlaceholderIdsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public Builder clearReturnPlaceholderIds() {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          returnPlaceholderIds_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000008);
+          onChanged();
+        } else {
+          returnPlaceholderIdsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public Builder removeReturnPlaceholderIds(int index) {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          ensureReturnPlaceholderIdsIsMutable();
+          returnPlaceholderIds_.remove(index);
+          onChanged();
+        } else {
+          returnPlaceholderIdsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder getReturnPlaceholderIdsBuilder(
+          int index) {
+        return getReturnPlaceholderIdsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder getReturnPlaceholderIdsOrBuilder(
+          int index) {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          return returnPlaceholderIds_.get(index);  } else {
+          return returnPlaceholderIdsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public java.util.List<? extends org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder> 
+           getReturnPlaceholderIdsOrBuilderList() {
+        if (returnPlaceholderIdsBuilder_ != null) {
+          return returnPlaceholderIdsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(returnPlaceholderIds_);
+        }
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder addReturnPlaceholderIdsBuilder() {
+        return getReturnPlaceholderIdsFieldBuilder().addBuilder(
+            org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder addReturnPlaceholderIdsBuilder(
+          int index) {
+        return getReturnPlaceholderIdsFieldBuilder().addBuilder(
+            index, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8[json_name = "returnPlaceholderIds"];</code>
+       */
+      public java.util.List<org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder> 
+           getReturnPlaceholderIdsBuilderList() {
+        return getReturnPlaceholderIdsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder> 
+          getReturnPlaceholderIdsFieldBuilder() {
+        if (returnPlaceholderIdsBuilder_ == null) {
+          returnPlaceholderIdsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderId.Builder, org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.PlaceholderIdOrBuilder>(
+                  returnPlaceholderIds_,
+                  ((bitField0_ & 0x00000008) != 0),
+                  getParentForChildren(),
+                  isClean());
+          returnPlaceholderIds_ = null;
+        }
+        return returnPlaceholderIdsBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -1677,41 +2974,60 @@ public final class CommunicationActionOuterClass {
   static {
     java.lang.String[] descriptorData = {
       "\n2syft_proto/execution/v1/communication_" +
-      "action.proto\022\027syft_proto.execution.v1\032\"s" +
-      "yft_proto/types/syft/v1/arg.proto\032!syft_" +
-      "proto/types/syft/v1/id.proto\"\202\003\n\023Communi" +
-      "cationAction\022\022\n\004name\030\001 \001(\tR\004name\0223\n\006obj_" +
-      "id\030\002 \001(\0132\034.syft_proto.types.syft.v1.IdR\005" +
-      "objId\0224\n\006source\030\003 \001(\0132\034.syft_proto.types" +
-      ".syft.v1.IdR\006source\022@\n\014destinations\030\004 \003(" +
-      "\0132\034.syft_proto.types.syft.v1.IdR\014destina" +
-      "tions\022P\n\006kwargs\030\005 \003(\01328.syft_proto.execu" +
-      "tion.v1.CommunicationAction.KwargsEntryR" +
-      "\006kwargs\032X\n\013KwargsEntry\022\020\n\003key\030\001 \001(\tR\003key" +
-      "\0223\n\005value\030\002 \001(\0132\035.syft_proto.types.syft." +
-      "v1.ArgR\005value:\0028\001B&\n$org.openmined.syftp" +
-      "roto.execution.v1b\006proto3"
+      "action.proto\022\027syft_proto.execution.v1\032,s" +
+      "yft_proto/execution/v1/placeholder_id.pr" +
+      "oto\0323syft_proto/generic/pointers/v1/poin" +
+      "ter_tensor.proto\032\"syft_proto/types/syft/" +
+      "v1/arg.proto\032!syft_proto/types/syft/v1/i" +
+      "d.proto\032&syft_proto/types/torch/v1/tenso" +
+      "r.proto\"\365\005\n\023CommunicationAction\022\030\n\007comma" +
+      "nd\030\001 \001(\tR\007command\022;\n\ttarget_id\030\t \001(\0132\034.s" +
+      "yft_proto.types.syft.v1.IdH\000R\010targetId\022V" +
+      "\n\016target_pointer\030\002 \001(\0132-.syft_proto.gene" +
+      "ric.pointers.v1.PointerTensorH\000R\rtargetP" +
+      "ointer\022\\\n\025target_placeholder_id\030\003 \001(\0132&." +
+      "syft_proto.execution.v1.PlaceholderIdH\000R" +
+      "\023targetPlaceholderId\022M\n\rtarget_tensor\030\004 " +
+      "\001(\0132&.syft_proto.types.torch.v1.TorchTen" +
+      "sorH\000R\014targetTensor\0221\n\004args\030\005 \003(\0132\035.syft" +
+      "_proto.types.syft.v1.ArgR\004args\022P\n\006kwargs" +
+      "\030\006 \003(\01328.syft_proto.execution.v1.Communi" +
+      "cationAction.KwargsEntryR\006kwargs\022;\n\nretu" +
+      "rn_ids\030\007 \003(\0132\034.syft_proto.types.syft.v1." +
+      "IdR\treturnIds\022\\\n\026return_placeholder_ids\030" +
+      "\010 \003(\0132&.syft_proto.execution.v1.Placehol" +
+      "derIdR\024returnPlaceholderIds\032X\n\013KwargsEnt" +
+      "ry\022\020\n\003key\030\001 \001(\tR\003key\0223\n\005value\030\002 \001(\0132\035.sy" +
+      "ft_proto.types.syft.v1.ArgR\005value:\0028\001B\010\n" +
+      "\006targetB&\n$org.openmined.syftproto.execu" +
+      "tion.v1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
+          org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.getDescriptor(),
+          org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.getDescriptor(),
           org.openmined.syftproto.types.syft.v1.ArgOuterClass.getDescriptor(),
           org.openmined.syftproto.types.syft.v1.IdOuterClass.getDescriptor(),
+          org.openmined.syftproto.types.torch.v1.Tensor.getDescriptor(),
         });
     internal_static_syft_proto_execution_v1_CommunicationAction_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_syft_proto_execution_v1_CommunicationAction_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_syft_proto_execution_v1_CommunicationAction_descriptor,
-        new java.lang.String[] { "Name", "ObjId", "Source", "Destinations", "Kwargs", });
+        new java.lang.String[] { "Command", "TargetId", "TargetPointer", "TargetPlaceholderId", "TargetTensor", "Args", "Kwargs", "ReturnIds", "ReturnPlaceholderIds", "Target", });
     internal_static_syft_proto_execution_v1_CommunicationAction_KwargsEntry_descriptor =
       internal_static_syft_proto_execution_v1_CommunicationAction_descriptor.getNestedTypes().get(0);
     internal_static_syft_proto_execution_v1_CommunicationAction_KwargsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_syft_proto_execution_v1_CommunicationAction_KwargsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
+    org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.getDescriptor();
+    org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.getDescriptor();
     org.openmined.syftproto.types.syft.v1.ArgOuterClass.getDescriptor();
     org.openmined.syftproto.types.syft.v1.IdOuterClass.getDescriptor();
+    org.openmined.syftproto.types.torch.v1.Tensor.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/jvm/src/main/java/org/openmined/syftproto/types/syft/v1/ArgOuterClass.java
+++ b/jvm/src/main/java/org/openmined/syftproto/types/syft/v1/ArgOuterClass.java
@@ -37,16 +37,16 @@ public final class ArgOuterClass {
     float getArgFloat();
 
     /**
-     * <code>string arg_string = 4[json_name = "argString"];</code>
-     * @return The argString.
+     * <code>string arg_str = 4[json_name = "argStr"];</code>
+     * @return The argStr.
      */
-    java.lang.String getArgString();
+    java.lang.String getArgStr();
     /**
-     * <code>string arg_string = 4[json_name = "argString"];</code>
-     * @return The bytes for argString.
+     * <code>string arg_str = 4[json_name = "argStr"];</code>
+     * @return The bytes for argStr.
      */
     com.google.protobuf.ByteString
-        getArgStringBytes();
+        getArgStrBytes();
 
     /**
      * <code>.syft_proto.types.syft.v1.Shape arg_shape = 5[json_name = "argShape"];</code>
@@ -330,7 +330,7 @@ public final class ArgOuterClass {
       ARG_BOOL(1),
       ARG_INT(2),
       ARG_FLOAT(3),
-      ARG_STRING(4),
+      ARG_STR(4),
       ARG_SHAPE(5),
       ARG_TENSOR(6),
       ARG_TORCH_PARAM(7),
@@ -357,7 +357,7 @@ public final class ArgOuterClass {
           case 1: return ARG_BOOL;
           case 2: return ARG_INT;
           case 3: return ARG_FLOAT;
-          case 4: return ARG_STRING;
+          case 4: return ARG_STR;
           case 5: return ARG_SHAPE;
           case 6: return ARG_TENSOR;
           case 7: return ARG_TORCH_PARAM;
@@ -415,12 +415,12 @@ public final class ArgOuterClass {
       return 0F;
     }
 
-    public static final int ARG_STRING_FIELD_NUMBER = 4;
+    public static final int ARG_STR_FIELD_NUMBER = 4;
     /**
-     * <code>string arg_string = 4[json_name = "argString"];</code>
-     * @return The argString.
+     * <code>string arg_str = 4[json_name = "argStr"];</code>
+     * @return The argStr.
      */
-    public java.lang.String getArgString() {
+    public java.lang.String getArgStr() {
       java.lang.Object ref = "";
       if (argCase_ == 4) {
         ref = arg_;
@@ -438,11 +438,11 @@ public final class ArgOuterClass {
       }
     }
     /**
-     * <code>string arg_string = 4[json_name = "argString"];</code>
-     * @return The bytes for argString.
+     * <code>string arg_str = 4[json_name = "argStr"];</code>
+     * @return The bytes for argStr.
      */
     public com.google.protobuf.ByteString
-        getArgStringBytes() {
+        getArgStrBytes() {
       java.lang.Object ref = "";
       if (argCase_ == 4) {
         ref = arg_;
@@ -757,8 +757,8 @@ public final class ArgOuterClass {
                   other.getArgFloat())) return false;
           break;
         case 4:
-          if (!getArgString()
-              .equals(other.getArgString())) return false;
+          if (!getArgStr()
+              .equals(other.getArgStr())) return false;
           break;
         case 5:
           if (!getArgShape()
@@ -814,8 +814,8 @@ public final class ArgOuterClass {
               getArgFloat());
           break;
         case 4:
-          hash = (37 * hash) + ARG_STRING_FIELD_NUMBER;
-          hash = (53 * hash) + getArgString().hashCode();
+          hash = (37 * hash) + ARG_STR_FIELD_NUMBER;
+          hash = (53 * hash) + getArgStr().hashCode();
           break;
         case 5:
           hash = (37 * hash) + ARG_SHAPE_FIELD_NUMBER;
@@ -1121,7 +1121,7 @@ public final class ArgOuterClass {
             setArgFloat(other.getArgFloat());
             break;
           }
-          case ARG_STRING: {
+          case ARG_STR: {
             argCase_ = 4;
             arg_ = other.arg_;
             onChanged();
@@ -1302,10 +1302,10 @@ public final class ArgOuterClass {
       }
 
       /**
-       * <code>string arg_string = 4[json_name = "argString"];</code>
-       * @return The argString.
+       * <code>string arg_str = 4[json_name = "argStr"];</code>
+       * @return The argStr.
        */
-      public java.lang.String getArgString() {
+      public java.lang.String getArgStr() {
         java.lang.Object ref = "";
         if (argCase_ == 4) {
           ref = arg_;
@@ -1323,11 +1323,11 @@ public final class ArgOuterClass {
         }
       }
       /**
-       * <code>string arg_string = 4[json_name = "argString"];</code>
-       * @return The bytes for argString.
+       * <code>string arg_str = 4[json_name = "argStr"];</code>
+       * @return The bytes for argStr.
        */
       public com.google.protobuf.ByteString
-          getArgStringBytes() {
+          getArgStrBytes() {
         java.lang.Object ref = "";
         if (argCase_ == 4) {
           ref = arg_;
@@ -1345,11 +1345,11 @@ public final class ArgOuterClass {
         }
       }
       /**
-       * <code>string arg_string = 4[json_name = "argString"];</code>
-       * @param value The argString to set.
+       * <code>string arg_str = 4[json_name = "argStr"];</code>
+       * @param value The argStr to set.
        * @return This builder for chaining.
        */
-      public Builder setArgString(
+      public Builder setArgStr(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
@@ -1360,10 +1360,10 @@ public final class ArgOuterClass {
         return this;
       }
       /**
-       * <code>string arg_string = 4[json_name = "argString"];</code>
+       * <code>string arg_str = 4[json_name = "argStr"];</code>
        * @return This builder for chaining.
        */
-      public Builder clearArgString() {
+      public Builder clearArgStr() {
         if (argCase_ == 4) {
           argCase_ = 0;
           arg_ = null;
@@ -1372,11 +1372,11 @@ public final class ArgOuterClass {
         return this;
       }
       /**
-       * <code>string arg_string = 4[json_name = "argString"];</code>
-       * @param value The bytes for argString to set.
+       * <code>string arg_str = 4[json_name = "argStr"];</code>
+       * @param value The bytes for argStr to set.
        * @return This builder for chaining.
        */
-      public Builder setArgStringBytes(
+      public Builder setArgStrBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -2290,23 +2290,23 @@ public final class ArgOuterClass {
       "roto\032&syft_proto/types/torch/v1/tensor.p" +
       "roto\032$syft_proto/types/syft/v1/shape.pro" +
       "to\032)syft_proto/types/torch/v1/parameter." +
-      "proto\"\345\004\n\003Arg\022\033\n\010arg_bool\030\001 \001(\010H\000R\007argBo" +
+      "proto\"\337\004\n\003Arg\022\033\n\010arg_bool\030\001 \001(\010H\000R\007argBo" +
       "ol\022\031\n\007arg_int\030\002 \001(\005H\000R\006argInt\022\035\n\targ_flo" +
-      "at\030\003 \001(\002H\000R\010argFloat\022\037\n\narg_string\030\004 \001(\t" +
-      "H\000R\targString\022>\n\targ_shape\030\005 \001(\0132\037.syft_" +
-      "proto.types.syft.v1.ShapeH\000R\010argShape\022G\n" +
-      "\narg_tensor\030\006 \001(\0132&.syft_proto.types.tor" +
-      "ch.v1.TorchTensorH\000R\targTensor\022N\n\017arg_to" +
-      "rch_param\030\007 \001(\0132$.syft_proto.types.torch" +
-      ".v1.ParameterH\000R\rargTorchParam\022]\n\022arg_po" +
-      "inter_tensor\030\010 \001(\0132-.syft_proto.generic." +
-      "pointers.v1.PointerTensorH\000R\020argPointerT" +
-      "ensor\022O\n\017arg_placeholder\030\t \001(\0132$.syft_pr" +
-      "oto.execution.v1.PlaceholderH\000R\016argPlace" +
-      "holder\022V\n\022arg_placeholder_id\030\n \001(\0132&.syf" +
-      "t_proto.execution.v1.PlaceholderIdH\000R\020ar" +
-      "gPlaceholderIdB\005\n\003argB\'\n%org.openmined.s" +
-      "yftproto.types.syft.v1b\006proto3"
+      "at\030\003 \001(\002H\000R\010argFloat\022\031\n\007arg_str\030\004 \001(\tH\000R" +
+      "\006argStr\022>\n\targ_shape\030\005 \001(\0132\037.syft_proto." +
+      "types.syft.v1.ShapeH\000R\010argShape\022G\n\narg_t" +
+      "ensor\030\006 \001(\0132&.syft_proto.types.torch.v1." +
+      "TorchTensorH\000R\targTensor\022N\n\017arg_torch_pa" +
+      "ram\030\007 \001(\0132$.syft_proto.types.torch.v1.Pa" +
+      "rameterH\000R\rargTorchParam\022]\n\022arg_pointer_" +
+      "tensor\030\010 \001(\0132-.syft_proto.generic.pointe" +
+      "rs.v1.PointerTensorH\000R\020argPointerTensor\022" +
+      "O\n\017arg_placeholder\030\t \001(\0132$.syft_proto.ex" +
+      "ecution.v1.PlaceholderH\000R\016argPlaceholder" +
+      "\022V\n\022arg_placeholder_id\030\n \001(\0132&.syft_prot" +
+      "o.execution.v1.PlaceholderIdH\000R\020argPlace" +
+      "holderIdB\005\n\003argB\'\n%org.openmined.syftpro" +
+      "to.types.syft.v1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -2323,7 +2323,7 @@ public final class ArgOuterClass {
     internal_static_syft_proto_types_syft_v1_Arg_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_syft_proto_types_syft_v1_Arg_descriptor,
-        new java.lang.String[] { "ArgBool", "ArgInt", "ArgFloat", "ArgString", "ArgShape", "ArgTensor", "ArgTorchParam", "ArgPointerTensor", "ArgPlaceholder", "ArgPlaceholderId", "Arg", });
+        new java.lang.String[] { "ArgBool", "ArgInt", "ArgFloat", "ArgStr", "ArgShape", "ArgTensor", "ArgTorchParam", "ArgPointerTensor", "ArgPlaceholder", "ArgPlaceholderId", "Arg", });
     org.openmined.syftproto.execution.v1.PlaceholderOuterClass.getDescriptor();
     org.openmined.syftproto.execution.v1.PlaceholderIdOuterClass.getDescriptor();
     org.openmined.syftproto.generic.pointers.v1.PointerTensorOuterClass.getDescriptor();

--- a/protobuf/syft_proto/execution/v1/communication_action.proto
+++ b/protobuf/syft_proto/execution/v1/communication_action.proto
@@ -3,13 +3,22 @@ syntax = "proto3";
 package syft_proto.execution.v1;
 option java_package = "org.openmined.syftproto.execution.v1";
 
+import "syft_proto/execution/v1/placeholder_id.proto";
+import "syft_proto/generic/pointers/v1/pointer_tensor.proto";
 import "syft_proto/types/syft/v1/arg.proto";
 import "syft_proto/types/syft/v1/id.proto";
+import "syft_proto/types/torch/v1/tensor.proto";
 
 message CommunicationAction {
-    string name = 1;
-    syft_proto.types.syft.v1.Id obj_id = 2;
-    syft_proto.types.syft.v1.Id source = 3;
-    repeated syft_proto.types.syft.v1.Id destinations = 4;
-    map<string, syft_proto.types.syft.v1.Arg> kwargs = 5;
+    string command = 1;
+    oneof target {
+        syft_proto.types.syft.v1.Id target_id = 9;
+        syft_proto.generic.pointers.v1.PointerTensor target_pointer = 2;
+        syft_proto.execution.v1.PlaceholderId target_placeholder_id = 3;
+        syft_proto.types.torch.v1.TorchTensor target_tensor = 4;
+    }
+    repeated syft_proto.types.syft.v1.Arg args = 5;
+    map<string, syft_proto.types.syft.v1.Arg> kwargs = 6;
+    repeated syft_proto.types.syft.v1.Id return_ids = 7;
+    repeated syft_proto.execution.v1.PlaceholderId return_placeholder_ids = 8;
 }

--- a/protobuf/syft_proto/types/syft/v1/arg.proto
+++ b/protobuf/syft_proto/types/syft/v1/arg.proto
@@ -15,7 +15,7 @@ message Arg {
         bool arg_bool = 1;
         int32 arg_int = 2;
         float arg_float = 3;
-        string arg_string = 4;
+        string arg_str = 4;
 
         syft_proto.types.syft.v1.Shape arg_shape = 5;
         syft_proto.types.torch.v1.TorchTensor arg_tensor = 6;

--- a/swift/syft_proto/execution/v1/communication_action.pb.swift
+++ b/swift/syft_proto/execution/v1/communication_action.pb.swift
@@ -24,36 +24,72 @@ struct SyftProto_Execution_V1_CommunicationAction {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var name: String = String()
+  var command: String = String()
 
-  var objID: SyftProto_Types_Syft_V1_Id {
-    get {return _objID ?? SyftProto_Types_Syft_V1_Id()}
-    set {_objID = newValue}
+  var target: SyftProto_Execution_V1_CommunicationAction.OneOf_Target? = nil
+
+  var targetID: SyftProto_Types_Syft_V1_Id {
+    get {
+      if case .targetID(let v)? = target {return v}
+      return SyftProto_Types_Syft_V1_Id()
+    }
+    set {target = .targetID(newValue)}
   }
-  /// Returns true if `objID` has been explicitly set.
-  var hasObjID: Bool {return self._objID != nil}
-  /// Clears the value of `objID`. Subsequent reads from it will return its default value.
-  mutating func clearObjID() {self._objID = nil}
 
-  var source: SyftProto_Types_Syft_V1_Id {
-    get {return _source ?? SyftProto_Types_Syft_V1_Id()}
-    set {_source = newValue}
+  var targetPointer: SyftProto_Generic_Pointers_V1_PointerTensor {
+    get {
+      if case .targetPointer(let v)? = target {return v}
+      return SyftProto_Generic_Pointers_V1_PointerTensor()
+    }
+    set {target = .targetPointer(newValue)}
   }
-  /// Returns true if `source` has been explicitly set.
-  var hasSource: Bool {return self._source != nil}
-  /// Clears the value of `source`. Subsequent reads from it will return its default value.
-  mutating func clearSource() {self._source = nil}
 
-  var destinations: [SyftProto_Types_Syft_V1_Id] = []
+  var targetPlaceholderID: SyftProto_Execution_V1_PlaceholderId {
+    get {
+      if case .targetPlaceholderID(let v)? = target {return v}
+      return SyftProto_Execution_V1_PlaceholderId()
+    }
+    set {target = .targetPlaceholderID(newValue)}
+  }
+
+  var targetTensor: SyftProto_Types_Torch_V1_TorchTensor {
+    get {
+      if case .targetTensor(let v)? = target {return v}
+      return SyftProto_Types_Torch_V1_TorchTensor()
+    }
+    set {target = .targetTensor(newValue)}
+  }
+
+  var args: [SyftProto_Types_Syft_V1_Arg] = []
 
   var kwargs: Dictionary<String,SyftProto_Types_Syft_V1_Arg> = [:]
 
+  var returnIds: [SyftProto_Types_Syft_V1_Id] = []
+
+  var returnPlaceholderIds: [SyftProto_Execution_V1_PlaceholderId] = []
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  init() {}
+  enum OneOf_Target: Equatable {
+    case targetID(SyftProto_Types_Syft_V1_Id)
+    case targetPointer(SyftProto_Generic_Pointers_V1_PointerTensor)
+    case targetPlaceholderID(SyftProto_Execution_V1_PlaceholderId)
+    case targetTensor(SyftProto_Types_Torch_V1_TorchTensor)
 
-  fileprivate var _objID: SyftProto_Types_Syft_V1_Id? = nil
-  fileprivate var _source: SyftProto_Types_Syft_V1_Id? = nil
+  #if !swift(>=4.1)
+    static func ==(lhs: SyftProto_Execution_V1_CommunicationAction.OneOf_Target, rhs: SyftProto_Execution_V1_CommunicationAction.OneOf_Target) -> Bool {
+      switch (lhs, rhs) {
+      case (.targetID(let l), .targetID(let r)): return l == r
+      case (.targetPointer(let l), .targetPointer(let r)): return l == r
+      case (.targetPlaceholderID(let l), .targetPlaceholderID(let r)): return l == r
+      case (.targetTensor(let l), .targetTensor(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
+  }
+
+  init() {}
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -63,51 +99,101 @@ fileprivate let _protobuf_package = "syft_proto.execution.v1"
 extension SyftProto_Execution_V1_CommunicationAction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CommunicationAction"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "name"),
-    2: .standard(proto: "obj_id"),
-    3: .same(proto: "source"),
-    4: .same(proto: "destinations"),
-    5: .same(proto: "kwargs"),
+    1: .same(proto: "command"),
+    9: .standard(proto: "target_id"),
+    2: .standard(proto: "target_pointer"),
+    3: .standard(proto: "target_placeholder_id"),
+    4: .standard(proto: "target_tensor"),
+    5: .same(proto: "args"),
+    6: .same(proto: "kwargs"),
+    7: .standard(proto: "return_ids"),
+    8: .standard(proto: "return_placeholder_ids"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       switch fieldNumber {
-      case 1: try decoder.decodeSingularStringField(value: &self.name)
-      case 2: try decoder.decodeSingularMessageField(value: &self._objID)
-      case 3: try decoder.decodeSingularMessageField(value: &self._source)
-      case 4: try decoder.decodeRepeatedMessageField(value: &self.destinations)
-      case 5: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,SyftProto_Types_Syft_V1_Arg>.self, value: &self.kwargs)
+      case 1: try decoder.decodeSingularStringField(value: &self.command)
+      case 2:
+        var v: SyftProto_Generic_Pointers_V1_PointerTensor?
+        if let current = self.target {
+          try decoder.handleConflictingOneOf()
+          if case .targetPointer(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.target = .targetPointer(v)}
+      case 3:
+        var v: SyftProto_Execution_V1_PlaceholderId?
+        if let current = self.target {
+          try decoder.handleConflictingOneOf()
+          if case .targetPlaceholderID(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.target = .targetPlaceholderID(v)}
+      case 4:
+        var v: SyftProto_Types_Torch_V1_TorchTensor?
+        if let current = self.target {
+          try decoder.handleConflictingOneOf()
+          if case .targetTensor(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.target = .targetTensor(v)}
+      case 5: try decoder.decodeRepeatedMessageField(value: &self.args)
+      case 6: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,SyftProto_Types_Syft_V1_Arg>.self, value: &self.kwargs)
+      case 7: try decoder.decodeRepeatedMessageField(value: &self.returnIds)
+      case 8: try decoder.decodeRepeatedMessageField(value: &self.returnPlaceholderIds)
+      case 9:
+        var v: SyftProto_Types_Syft_V1_Id?
+        if let current = self.target {
+          try decoder.handleConflictingOneOf()
+          if case .targetID(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.target = .targetID(v)}
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.name.isEmpty {
-      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    if !self.command.isEmpty {
+      try visitor.visitSingularStringField(value: self.command, fieldNumber: 1)
     }
-    if let v = self._objID {
+    switch self.target {
+    case .targetPointer(let v)?:
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
-    if let v = self._source {
+    case .targetPlaceholderID(let v)?:
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    case .targetTensor(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    case nil: break
+    default: break
     }
-    if !self.destinations.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.destinations, fieldNumber: 4)
+    if !self.args.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.args, fieldNumber: 5)
     }
     if !self.kwargs.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,SyftProto_Types_Syft_V1_Arg>.self, value: self.kwargs, fieldNumber: 5)
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,SyftProto_Types_Syft_V1_Arg>.self, value: self.kwargs, fieldNumber: 6)
+    }
+    if !self.returnIds.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.returnIds, fieldNumber: 7)
+    }
+    if !self.returnPlaceholderIds.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.returnPlaceholderIds, fieldNumber: 8)
+    }
+    if case .targetID(let v)? = self.target {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SyftProto_Execution_V1_CommunicationAction, rhs: SyftProto_Execution_V1_CommunicationAction) -> Bool {
-    if lhs.name != rhs.name {return false}
-    if lhs._objID != rhs._objID {return false}
-    if lhs._source != rhs._source {return false}
-    if lhs.destinations != rhs.destinations {return false}
+    if lhs.command != rhs.command {return false}
+    if lhs.target != rhs.target {return false}
+    if lhs.args != rhs.args {return false}
     if lhs.kwargs != rhs.kwargs {return false}
+    if lhs.returnIds != rhs.returnIds {return false}
+    if lhs.returnPlaceholderIds != rhs.returnPlaceholderIds {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/swift/syft_proto/types/syft/v1/arg.pb.swift
+++ b/swift/syft_proto/types/syft/v1/arg.pb.swift
@@ -50,12 +50,12 @@ struct SyftProto_Types_Syft_V1_Arg {
     set {arg = .argFloat(newValue)}
   }
 
-  var argString: String {
+  var argStr: String {
     get {
-      if case .argString(let v)? = arg {return v}
+      if case .argStr(let v)? = arg {return v}
       return String()
     }
-    set {arg = .argString(newValue)}
+    set {arg = .argStr(newValue)}
   }
 
   var argShape: SyftProto_Types_Syft_V1_Shape {
@@ -112,7 +112,7 @@ struct SyftProto_Types_Syft_V1_Arg {
     case argBool(Bool)
     case argInt(Int32)
     case argFloat(Float)
-    case argString(String)
+    case argStr(String)
     case argShape(SyftProto_Types_Syft_V1_Shape)
     case argTensor(SyftProto_Types_Torch_V1_TorchTensor)
     case argTorchParam(SyftProto_Types_Torch_V1_Parameter)
@@ -126,7 +126,7 @@ struct SyftProto_Types_Syft_V1_Arg {
       case (.argBool(let l), .argBool(let r)): return l == r
       case (.argInt(let l), .argInt(let r)): return l == r
       case (.argFloat(let l), .argFloat(let r)): return l == r
-      case (.argString(let l), .argString(let r)): return l == r
+      case (.argStr(let l), .argStr(let r)): return l == r
       case (.argShape(let l), .argShape(let r)): return l == r
       case (.argTensor(let l), .argTensor(let r)): return l == r
       case (.argTorchParam(let l), .argTorchParam(let r)): return l == r
@@ -152,7 +152,7 @@ extension SyftProto_Types_Syft_V1_Arg: SwiftProtobuf.Message, SwiftProtobuf._Mes
     1: .standard(proto: "arg_bool"),
     2: .standard(proto: "arg_int"),
     3: .standard(proto: "arg_float"),
-    4: .standard(proto: "arg_string"),
+    4: .standard(proto: "arg_str"),
     5: .standard(proto: "arg_shape"),
     6: .standard(proto: "arg_tensor"),
     7: .standard(proto: "arg_torch_param"),
@@ -183,7 +183,7 @@ extension SyftProto_Types_Syft_V1_Arg: SwiftProtobuf.Message, SwiftProtobuf._Mes
         if self.arg != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.arg = .argString(v)}
+        if let v = v {self.arg = .argStr(v)}
       case 5:
         var v: SyftProto_Types_Syft_V1_Shape?
         if let current = self.arg {
@@ -245,7 +245,7 @@ extension SyftProto_Types_Syft_V1_Arg: SwiftProtobuf.Message, SwiftProtobuf._Mes
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
     case .argFloat(let v)?:
       try visitor.visitSingularFloatField(value: v, fieldNumber: 3)
-    case .argString(let v)?:
+    case .argStr(let v)?:
       try visitor.visitSingularStringField(value: v, fieldNumber: 4)
     case .argShape(let v)?:
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)

--- a/syft_proto/execution/v1/communication_action_pb2.py
+++ b/syft_proto/execution/v1/communication_action_pb2.py
@@ -11,8 +11,11 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
+from syft_proto.execution.v1 import placeholder_id_pb2 as syft__proto_dot_execution_dot_v1_dot_placeholder__id__pb2
+from syft_proto.generic.pointers.v1 import pointer_tensor_pb2 as syft__proto_dot_generic_dot_pointers_dot_v1_dot_pointer__tensor__pb2
 from syft_proto.types.syft.v1 import arg_pb2 as syft__proto_dot_types_dot_syft_dot_v1_dot_arg__pb2
 from syft_proto.types.syft.v1 import id_pb2 as syft__proto_dot_types_dot_syft_dot_v1_dot_id__pb2
+from syft_proto.types.torch.v1 import tensor_pb2 as syft__proto_dot_types_dot_torch_dot_v1_dot_tensor__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -20,9 +23,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='syft_proto.execution.v1',
   syntax='proto3',
   serialized_options=b'\n$org.openmined.syftproto.execution.v1',
-  serialized_pb=b'\n2syft_proto/execution/v1/communication_action.proto\x12\x17syft_proto.execution.v1\x1a\"syft_proto/types/syft/v1/arg.proto\x1a!syft_proto/types/syft/v1/id.proto\"\x82\x03\n\x13\x43ommunicationAction\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x33\n\x06obj_id\x18\x02 \x01(\x0b\x32\x1c.syft_proto.types.syft.v1.IdR\x05objId\x12\x34\n\x06source\x18\x03 \x01(\x0b\x32\x1c.syft_proto.types.syft.v1.IdR\x06source\x12@\n\x0c\x64\x65stinations\x18\x04 \x03(\x0b\x32\x1c.syft_proto.types.syft.v1.IdR\x0c\x64\x65stinations\x12P\n\x06kwargs\x18\x05 \x03(\x0b\x32\x38.syft_proto.execution.v1.CommunicationAction.KwargsEntryR\x06kwargs\x1aX\n\x0bKwargsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x33\n\x05value\x18\x02 \x01(\x0b\x32\x1d.syft_proto.types.syft.v1.ArgR\x05value:\x02\x38\x01\x42&\n$org.openmined.syftproto.execution.v1b\x06proto3'
+  serialized_pb=b'\n2syft_proto/execution/v1/communication_action.proto\x12\x17syft_proto.execution.v1\x1a,syft_proto/execution/v1/placeholder_id.proto\x1a\x33syft_proto/generic/pointers/v1/pointer_tensor.proto\x1a\"syft_proto/types/syft/v1/arg.proto\x1a!syft_proto/types/syft/v1/id.proto\x1a&syft_proto/types/torch/v1/tensor.proto\"\xf5\x05\n\x13\x43ommunicationAction\x12\x18\n\x07\x63ommand\x18\x01 \x01(\tR\x07\x63ommand\x12;\n\ttarget_id\x18\t \x01(\x0b\x32\x1c.syft_proto.types.syft.v1.IdH\x00R\x08targetId\x12V\n\x0etarget_pointer\x18\x02 \x01(\x0b\x32-.syft_proto.generic.pointers.v1.PointerTensorH\x00R\rtargetPointer\x12\\\n\x15target_placeholder_id\x18\x03 \x01(\x0b\x32&.syft_proto.execution.v1.PlaceholderIdH\x00R\x13targetPlaceholderId\x12M\n\rtarget_tensor\x18\x04 \x01(\x0b\x32&.syft_proto.types.torch.v1.TorchTensorH\x00R\x0ctargetTensor\x12\x31\n\x04\x61rgs\x18\x05 \x03(\x0b\x32\x1d.syft_proto.types.syft.v1.ArgR\x04\x61rgs\x12P\n\x06kwargs\x18\x06 \x03(\x0b\x32\x38.syft_proto.execution.v1.CommunicationAction.KwargsEntryR\x06kwargs\x12;\n\nreturn_ids\x18\x07 \x03(\x0b\x32\x1c.syft_proto.types.syft.v1.IdR\treturnIds\x12\\\n\x16return_placeholder_ids\x18\x08 \x03(\x0b\x32&.syft_proto.execution.v1.PlaceholderIdR\x14returnPlaceholderIds\x1aX\n\x0bKwargsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x33\n\x05value\x18\x02 \x01(\x0b\x32\x1d.syft_proto.types.syft.v1.ArgR\x05value:\x02\x38\x01\x42\x08\n\x06targetB&\n$org.openmined.syftproto.execution.v1b\x06proto3'
   ,
-  dependencies=[syft__proto_dot_types_dot_syft_dot_v1_dot_arg__pb2.DESCRIPTOR,syft__proto_dot_types_dot_syft_dot_v1_dot_id__pb2.DESCRIPTOR,])
+  dependencies=[syft__proto_dot_execution_dot_v1_dot_placeholder__id__pb2.DESCRIPTOR,syft__proto_dot_generic_dot_pointers_dot_v1_dot_pointer__tensor__pb2.DESCRIPTOR,syft__proto_dot_types_dot_syft_dot_v1_dot_arg__pb2.DESCRIPTOR,syft__proto_dot_types_dot_syft_dot_v1_dot_id__pb2.DESCRIPTOR,syft__proto_dot_types_dot_torch_dot_v1_dot_tensor__pb2.DESCRIPTOR,])
 
 
 
@@ -60,8 +63,8 @@ _COMMUNICATIONACTION_KWARGSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=449,
-  serialized_end=537,
+  serialized_start=949,
+  serialized_end=1037,
 )
 
 _COMMUNICATIONACTION = _descriptor.Descriptor(
@@ -72,40 +75,68 @@ _COMMUNICATIONACTION = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='syft_proto.execution.v1.CommunicationAction.name', index=0,
+      name='command', full_name='syft_proto.execution.v1.CommunicationAction.command', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=None, json_name='name', file=DESCRIPTOR),
+      serialized_options=None, json_name='command', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='obj_id', full_name='syft_proto.execution.v1.CommunicationAction.obj_id', index=1,
+      name='target_id', full_name='syft_proto.execution.v1.CommunicationAction.target_id', index=1,
+      number=9, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, json_name='targetId', file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='target_pointer', full_name='syft_proto.execution.v1.CommunicationAction.target_pointer', index=2,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=None, json_name='objId', file=DESCRIPTOR),
+      serialized_options=None, json_name='targetPointer', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='source', full_name='syft_proto.execution.v1.CommunicationAction.source', index=2,
+      name='target_placeholder_id', full_name='syft_proto.execution.v1.CommunicationAction.target_placeholder_id', index=3,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=None, json_name='source', file=DESCRIPTOR),
+      serialized_options=None, json_name='targetPlaceholderId', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='destinations', full_name='syft_proto.execution.v1.CommunicationAction.destinations', index=3,
-      number=4, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
+      name='target_tensor', full_name='syft_proto.execution.v1.CommunicationAction.target_tensor', index=4,
+      number=4, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=None, json_name='destinations', file=DESCRIPTOR),
+      serialized_options=None, json_name='targetTensor', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='kwargs', full_name='syft_proto.execution.v1.CommunicationAction.kwargs', index=4,
+      name='args', full_name='syft_proto.execution.v1.CommunicationAction.args', index=5,
       number=5, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
+      serialized_options=None, json_name='args', file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='kwargs', full_name='syft_proto.execution.v1.CommunicationAction.kwargs', index=6,
+      number=6, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
       serialized_options=None, json_name='kwargs', file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='return_ids', full_name='syft_proto.execution.v1.CommunicationAction.return_ids', index=7,
+      number=7, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, json_name='returnIds', file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='return_placeholder_ids', full_name='syft_proto.execution.v1.CommunicationAction.return_placeholder_ids', index=8,
+      number=8, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, json_name='returnPlaceholderIds', file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -117,17 +148,36 @@ _COMMUNICATIONACTION = _descriptor.Descriptor(
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
+    _descriptor.OneofDescriptor(
+      name='target', full_name='syft_proto.execution.v1.CommunicationAction.target',
+      index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=151,
-  serialized_end=537,
+  serialized_start=290,
+  serialized_end=1047,
 )
 
 _COMMUNICATIONACTION_KWARGSENTRY.fields_by_name['value'].message_type = syft__proto_dot_types_dot_syft_dot_v1_dot_arg__pb2._ARG
 _COMMUNICATIONACTION_KWARGSENTRY.containing_type = _COMMUNICATIONACTION
-_COMMUNICATIONACTION.fields_by_name['obj_id'].message_type = syft__proto_dot_types_dot_syft_dot_v1_dot_id__pb2._ID
-_COMMUNICATIONACTION.fields_by_name['source'].message_type = syft__proto_dot_types_dot_syft_dot_v1_dot_id__pb2._ID
-_COMMUNICATIONACTION.fields_by_name['destinations'].message_type = syft__proto_dot_types_dot_syft_dot_v1_dot_id__pb2._ID
+_COMMUNICATIONACTION.fields_by_name['target_id'].message_type = syft__proto_dot_types_dot_syft_dot_v1_dot_id__pb2._ID
+_COMMUNICATIONACTION.fields_by_name['target_pointer'].message_type = syft__proto_dot_generic_dot_pointers_dot_v1_dot_pointer__tensor__pb2._POINTERTENSOR
+_COMMUNICATIONACTION.fields_by_name['target_placeholder_id'].message_type = syft__proto_dot_execution_dot_v1_dot_placeholder__id__pb2._PLACEHOLDERID
+_COMMUNICATIONACTION.fields_by_name['target_tensor'].message_type = syft__proto_dot_types_dot_torch_dot_v1_dot_tensor__pb2._TORCHTENSOR
+_COMMUNICATIONACTION.fields_by_name['args'].message_type = syft__proto_dot_types_dot_syft_dot_v1_dot_arg__pb2._ARG
 _COMMUNICATIONACTION.fields_by_name['kwargs'].message_type = _COMMUNICATIONACTION_KWARGSENTRY
+_COMMUNICATIONACTION.fields_by_name['return_ids'].message_type = syft__proto_dot_types_dot_syft_dot_v1_dot_id__pb2._ID
+_COMMUNICATIONACTION.fields_by_name['return_placeholder_ids'].message_type = syft__proto_dot_execution_dot_v1_dot_placeholder__id__pb2._PLACEHOLDERID
+_COMMUNICATIONACTION.oneofs_by_name['target'].fields.append(
+  _COMMUNICATIONACTION.fields_by_name['target_id'])
+_COMMUNICATIONACTION.fields_by_name['target_id'].containing_oneof = _COMMUNICATIONACTION.oneofs_by_name['target']
+_COMMUNICATIONACTION.oneofs_by_name['target'].fields.append(
+  _COMMUNICATIONACTION.fields_by_name['target_pointer'])
+_COMMUNICATIONACTION.fields_by_name['target_pointer'].containing_oneof = _COMMUNICATIONACTION.oneofs_by_name['target']
+_COMMUNICATIONACTION.oneofs_by_name['target'].fields.append(
+  _COMMUNICATIONACTION.fields_by_name['target_placeholder_id'])
+_COMMUNICATIONACTION.fields_by_name['target_placeholder_id'].containing_oneof = _COMMUNICATIONACTION.oneofs_by_name['target']
+_COMMUNICATIONACTION.oneofs_by_name['target'].fields.append(
+  _COMMUNICATIONACTION.fields_by_name['target_tensor'])
+_COMMUNICATIONACTION.fields_by_name['target_tensor'].containing_oneof = _COMMUNICATIONACTION.oneofs_by_name['target']
 DESCRIPTOR.message_types_by_name['CommunicationAction'] = _COMMUNICATIONACTION
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 

--- a/syft_proto/types/syft/v1/arg_pb2.py
+++ b/syft_proto/types/syft/v1/arg_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='syft_proto.types.syft.v1',
   syntax='proto3',
   serialized_options=b'\n%org.openmined.syftproto.types.syft.v1',
-  serialized_pb=b'\n\"syft_proto/types/syft/v1/arg.proto\x12\x18syft_proto.types.syft.v1\x1a)syft_proto/execution/v1/placeholder.proto\x1a,syft_proto/execution/v1/placeholder_id.proto\x1a\x33syft_proto/generic/pointers/v1/pointer_tensor.proto\x1a&syft_proto/types/torch/v1/tensor.proto\x1a$syft_proto/types/syft/v1/shape.proto\x1a)syft_proto/types/torch/v1/parameter.proto\"\xe5\x04\n\x03\x41rg\x12\x1b\n\x08\x61rg_bool\x18\x01 \x01(\x08H\x00R\x07\x61rgBool\x12\x19\n\x07\x61rg_int\x18\x02 \x01(\x05H\x00R\x06\x61rgInt\x12\x1d\n\targ_float\x18\x03 \x01(\x02H\x00R\x08\x61rgFloat\x12\x1f\n\narg_string\x18\x04 \x01(\tH\x00R\targString\x12>\n\targ_shape\x18\x05 \x01(\x0b\x32\x1f.syft_proto.types.syft.v1.ShapeH\x00R\x08\x61rgShape\x12G\n\narg_tensor\x18\x06 \x01(\x0b\x32&.syft_proto.types.torch.v1.TorchTensorH\x00R\targTensor\x12N\n\x0f\x61rg_torch_param\x18\x07 \x01(\x0b\x32$.syft_proto.types.torch.v1.ParameterH\x00R\rargTorchParam\x12]\n\x12\x61rg_pointer_tensor\x18\x08 \x01(\x0b\x32-.syft_proto.generic.pointers.v1.PointerTensorH\x00R\x10\x61rgPointerTensor\x12O\n\x0f\x61rg_placeholder\x18\t \x01(\x0b\x32$.syft_proto.execution.v1.PlaceholderH\x00R\x0e\x61rgPlaceholder\x12V\n\x12\x61rg_placeholder_id\x18\n \x01(\x0b\x32&.syft_proto.execution.v1.PlaceholderIdH\x00R\x10\x61rgPlaceholderIdB\x05\n\x03\x61rgB\'\n%org.openmined.syftproto.types.syft.v1b\x06proto3'
+  serialized_pb=b'\n\"syft_proto/types/syft/v1/arg.proto\x12\x18syft_proto.types.syft.v1\x1a)syft_proto/execution/v1/placeholder.proto\x1a,syft_proto/execution/v1/placeholder_id.proto\x1a\x33syft_proto/generic/pointers/v1/pointer_tensor.proto\x1a&syft_proto/types/torch/v1/tensor.proto\x1a$syft_proto/types/syft/v1/shape.proto\x1a)syft_proto/types/torch/v1/parameter.proto\"\xdf\x04\n\x03\x41rg\x12\x1b\n\x08\x61rg_bool\x18\x01 \x01(\x08H\x00R\x07\x61rgBool\x12\x19\n\x07\x61rg_int\x18\x02 \x01(\x05H\x00R\x06\x61rgInt\x12\x1d\n\targ_float\x18\x03 \x01(\x02H\x00R\x08\x61rgFloat\x12\x19\n\x07\x61rg_str\x18\x04 \x01(\tH\x00R\x06\x61rgStr\x12>\n\targ_shape\x18\x05 \x01(\x0b\x32\x1f.syft_proto.types.syft.v1.ShapeH\x00R\x08\x61rgShape\x12G\n\narg_tensor\x18\x06 \x01(\x0b\x32&.syft_proto.types.torch.v1.TorchTensorH\x00R\targTensor\x12N\n\x0f\x61rg_torch_param\x18\x07 \x01(\x0b\x32$.syft_proto.types.torch.v1.ParameterH\x00R\rargTorchParam\x12]\n\x12\x61rg_pointer_tensor\x18\x08 \x01(\x0b\x32-.syft_proto.generic.pointers.v1.PointerTensorH\x00R\x10\x61rgPointerTensor\x12O\n\x0f\x61rg_placeholder\x18\t \x01(\x0b\x32$.syft_proto.execution.v1.PlaceholderH\x00R\x0e\x61rgPlaceholder\x12V\n\x12\x61rg_placeholder_id\x18\n \x01(\x0b\x32&.syft_proto.execution.v1.PlaceholderIdH\x00R\x10\x61rgPlaceholderIdB\x05\n\x03\x61rgB\'\n%org.openmined.syftproto.types.syft.v1b\x06proto3'
   ,
   dependencies=[syft__proto_dot_execution_dot_v1_dot_placeholder__pb2.DESCRIPTOR,syft__proto_dot_execution_dot_v1_dot_placeholder__id__pb2.DESCRIPTOR,syft__proto_dot_generic_dot_pointers_dot_v1_dot_pointer__tensor__pb2.DESCRIPTOR,syft__proto_dot_types_dot_torch_dot_v1_dot_tensor__pb2.DESCRIPTOR,syft__proto_dot_types_dot_syft_dot_v1_dot_shape__pb2.DESCRIPTOR,syft__proto_dot_types_dot_torch_dot_v1_dot_parameter__pb2.DESCRIPTOR,])
 
@@ -60,12 +60,12 @@ _ARG = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, json_name='argFloat', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='arg_string', full_name='syft_proto.types.syft.v1.Arg.arg_string', index=3,
+      name='arg_str', full_name='syft_proto.types.syft.v1.Arg.arg_str', index=3,
       number=4, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=None, json_name='argString', file=DESCRIPTOR),
+      serialized_options=None, json_name='argStr', file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='arg_shape', full_name='syft_proto.types.syft.v1.Arg.arg_shape', index=4,
       number=5, type=11, cpp_type=10, label=1,
@@ -124,7 +124,7 @@ _ARG = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=328,
-  serialized_end=941,
+  serialized_end=935,
 )
 
 _ARG.fields_by_name['arg_shape'].message_type = syft__proto_dot_types_dot_syft_dot_v1_dot_shape__pb2._SHAPE
@@ -143,8 +143,8 @@ _ARG.oneofs_by_name['arg'].fields.append(
   _ARG.fields_by_name['arg_float'])
 _ARG.fields_by_name['arg_float'].containing_oneof = _ARG.oneofs_by_name['arg']
 _ARG.oneofs_by_name['arg'].fields.append(
-  _ARG.fields_by_name['arg_string'])
-_ARG.fields_by_name['arg_string'].containing_oneof = _ARG.oneofs_by_name['arg']
+  _ARG.fields_by_name['arg_str'])
+_ARG.fields_by_name['arg_str'].containing_oneof = _ARG.oneofs_by_name['arg']
 _ARG.oneofs_by_name['arg'].fields.append(
   _ARG.fields_by_name['arg_shape'])
 _ARG.fields_by_name['arg_shape'].containing_oneof = _ARG.oneofs_by_name['arg']


### PR DESCRIPTION
This mostly standardizes the fields with `ComputationAction`, which makes it possible to register both action types interchangeably in Roles.