### PR TITLE
add protojson to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include syft_proto/_version.py
+include proto.json


### PR DESCRIPTION
syft uses syft-proto as a dependency, which means this package should also be added to conda.
proto.json isn't included in the pypi repo. 