### PR TITLE
Add base_framework and roles to Plan

### DIFF
--- a/js/protobuf.d.js
+++ b/js/protobuf.d.js
@@ -529,6 +529,12 @@ export namespace syft_proto {
 
                 /** Plan input_types */
                 input_types?: (syft_proto.execution.v1.INestedTypeWrapper|null);
+
+                /** Plan base_framework */
+                base_framework?: (string|null);
+
+                /** Plan roles */
+                roles?: ({ [k: string]: syft_proto.execution.v1.IRole }|null);
             }
 
             /** Represents a Plan. */
@@ -563,6 +569,12 @@ export namespace syft_proto {
 
                 /** Plan input_types. */
                 public input_types?: (syft_proto.execution.v1.INestedTypeWrapper|null);
+
+                /** Plan base_framework. */
+                public base_framework: string;
+
+                /** Plan roles. */
+                public roles: { [k: string]: syft_proto.execution.v1.IRole };
 
                 /**
                  * Creates a new Plan instance using the specified properties.

--- a/js/protobuf.js
+++ b/js/protobuf.js
@@ -1640,6 +1640,8 @@ $root.syft_proto = (function() {
                  * @property {string|null} [description] Plan description
                  * @property {Uint8Array|null} [torchscript] Plan torchscript
                  * @property {syft_proto.execution.v1.INestedTypeWrapper|null} [input_types] Plan input_types
+                 * @property {string|null} [base_framework] Plan base_framework
+                 * @property {Object.<string,syft_proto.execution.v1.IRole>|null} [roles] Plan roles
                  */
 
                 /**
@@ -1652,6 +1654,7 @@ $root.syft_proto = (function() {
                  */
                 function Plan(properties) {
                     this.tags = [];
+                    this.roles = {};
                     if (properties)
                         for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                             if (properties[keys[i]] != null)
@@ -1723,6 +1726,22 @@ $root.syft_proto = (function() {
                 Plan.prototype.input_types = null;
 
                 /**
+                 * Plan base_framework.
+                 * @member {string} base_framework
+                 * @memberof syft_proto.execution.v1.Plan
+                 * @instance
+                 */
+                Plan.prototype.base_framework = "";
+
+                /**
+                 * Plan roles.
+                 * @member {Object.<string,syft_proto.execution.v1.IRole>} roles
+                 * @memberof syft_proto.execution.v1.Plan
+                 * @instance
+                 */
+                Plan.prototype.roles = $util.emptyObject;
+
+                /**
                  * Creates a new Plan instance using the specified properties.
                  * @function create
                  * @memberof syft_proto.execution.v1.Plan
@@ -1763,6 +1782,13 @@ $root.syft_proto = (function() {
                         writer.uint32(/* id 7, wireType 2 =*/58).bytes(message.torchscript);
                     if (message.input_types != null && message.hasOwnProperty("input_types"))
                         $root.syft_proto.execution.v1.NestedTypeWrapper.encode(message.input_types, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                    if (message.base_framework != null && message.hasOwnProperty("base_framework"))
+                        writer.uint32(/* id 9, wireType 2 =*/74).string(message.base_framework);
+                    if (message.roles != null && message.hasOwnProperty("roles"))
+                        for (var keys = Object.keys(message.roles), i = 0; i < keys.length; ++i) {
+                            writer.uint32(/* id 10, wireType 2 =*/82).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
+                            $root.syft_proto.execution.v1.Role.encode(message.roles[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim().ldelim();
+                        }
                     return writer;
                 };
 
@@ -1793,7 +1819,7 @@ $root.syft_proto = (function() {
                 Plan.decode = function decode(reader, length) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
-                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.syft_proto.execution.v1.Plan();
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.syft_proto.execution.v1.Plan(), key;
                     while (reader.pos < end) {
                         var tag = reader.uint32();
                         switch (tag >>> 3) {
@@ -1822,6 +1848,17 @@ $root.syft_proto = (function() {
                             break;
                         case 8:
                             message.input_types = $root.syft_proto.execution.v1.NestedTypeWrapper.decode(reader, reader.uint32());
+                            break;
+                        case 9:
+                            message.base_framework = reader.string();
+                            break;
+                        case 10:
+                            reader.skip().pos++;
+                            if (message.roles === $util.emptyObject)
+                                message.roles = {};
+                            key = reader.string();
+                            reader.pos++;
+                            message.roles[key] = $root.syft_proto.execution.v1.Role.decode(reader, reader.uint32());
                             break;
                         default:
                             reader.skipType(tag & 7);
@@ -1892,6 +1929,19 @@ $root.syft_proto = (function() {
                         if (error)
                             return "input_types." + error;
                     }
+                    if (message.base_framework != null && message.hasOwnProperty("base_framework"))
+                        if (!$util.isString(message.base_framework))
+                            return "base_framework: string expected";
+                    if (message.roles != null && message.hasOwnProperty("roles")) {
+                        if (!$util.isObject(message.roles))
+                            return "roles: object expected";
+                        var key = Object.keys(message.roles);
+                        for (var i = 0; i < key.length; ++i) {
+                            var error = $root.syft_proto.execution.v1.Role.verify(message.roles[key[i]]);
+                            if (error)
+                                return "roles." + error;
+                        }
+                    }
                     return null;
                 };
 
@@ -1940,6 +1990,18 @@ $root.syft_proto = (function() {
                             throw TypeError(".syft_proto.execution.v1.Plan.input_types: object expected");
                         message.input_types = $root.syft_proto.execution.v1.NestedTypeWrapper.fromObject(object.input_types);
                     }
+                    if (object.base_framework != null)
+                        message.base_framework = String(object.base_framework);
+                    if (object.roles) {
+                        if (typeof object.roles !== "object")
+                            throw TypeError(".syft_proto.execution.v1.Plan.roles: object expected");
+                        message.roles = {};
+                        for (var keys = Object.keys(object.roles), i = 0; i < keys.length; ++i) {
+                            if (typeof object.roles[keys[i]] !== "object")
+                                throw TypeError(".syft_proto.execution.v1.Plan.roles: object expected");
+                            message.roles[keys[i]] = $root.syft_proto.execution.v1.Role.fromObject(object.roles[keys[i]]);
+                        }
+                    }
                     return message;
                 };
 
@@ -1958,6 +2020,8 @@ $root.syft_proto = (function() {
                     var object = {};
                     if (options.arrays || options.defaults)
                         object.tags = [];
+                    if (options.objects || options.defaults)
+                        object.roles = {};
                     if (options.defaults) {
                         object.id = null;
                         object.role = null;
@@ -1972,6 +2036,7 @@ $root.syft_proto = (function() {
                                 object.torchscript = $util.newBuffer(object.torchscript);
                         }
                         object.input_types = null;
+                        object.base_framework = "";
                     }
                     if (message.id != null && message.hasOwnProperty("id"))
                         object.id = $root.syft_proto.types.syft.v1.Id.toObject(message.id, options);
@@ -1992,6 +2057,14 @@ $root.syft_proto = (function() {
                         object.torchscript = options.bytes === String ? $util.base64.encode(message.torchscript, 0, message.torchscript.length) : options.bytes === Array ? Array.prototype.slice.call(message.torchscript) : message.torchscript;
                     if (message.input_types != null && message.hasOwnProperty("input_types"))
                         object.input_types = $root.syft_proto.execution.v1.NestedTypeWrapper.toObject(message.input_types, options);
+                    if (message.base_framework != null && message.hasOwnProperty("base_framework"))
+                        object.base_framework = message.base_framework;
+                    var keys2;
+                    if (message.roles && (keys2 = Object.keys(message.roles)).length) {
+                        object.roles = {};
+                        for (var j = 0; j < keys2.length; ++j)
+                            object.roles[keys2[j]] = $root.syft_proto.execution.v1.Role.toObject(message.roles[keys2[j]], options);
+                    }
                     return object;
                 };
 

--- a/jvm/src/main/java/org/openmined/syftproto/execution/v1/PlanOuterClass.java
+++ b/jvm/src/main/java/org/openmined/syftproto/execution/v1/PlanOuterClass.java
@@ -123,6 +123,52 @@ public final class PlanOuterClass {
      * <code>.syft_proto.execution.v1.NestedTypeWrapper input_types = 8[json_name = "inputTypes"];</code>
      */
     org.openmined.syftproto.execution.v1.TypeWrapper.NestedTypeWrapperOrBuilder getInputTypesOrBuilder();
+
+    /**
+     * <code>string base_framework = 9[json_name = "baseFramework"];</code>
+     * @return The baseFramework.
+     */
+    java.lang.String getBaseFramework();
+    /**
+     * <code>string base_framework = 9[json_name = "baseFramework"];</code>
+     * @return The bytes for baseFramework.
+     */
+    com.google.protobuf.ByteString
+        getBaseFrameworkBytes();
+
+    /**
+     * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+     */
+    int getRolesCount();
+    /**
+     * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+     */
+    boolean containsRoles(
+        java.lang.String key);
+    /**
+     * Use {@link #getRolesMap()} instead.
+     */
+    @java.lang.Deprecated
+    java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role>
+    getRoles();
+    /**
+     * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+     */
+    java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role>
+    getRolesMap();
+    /**
+     * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+     */
+
+    org.openmined.syftproto.execution.v1.RoleOuterClass.Role getRolesOrDefault(
+        java.lang.String key,
+        org.openmined.syftproto.execution.v1.RoleOuterClass.Role defaultValue);
+    /**
+     * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+     */
+
+    org.openmined.syftproto.execution.v1.RoleOuterClass.Role getRolesOrThrow(
+        java.lang.String key);
   }
   /**
    * Protobuf type {@code syft_proto.execution.v1.Plan}
@@ -141,6 +187,7 @@ public final class PlanOuterClass {
       tags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       description_ = "";
       torchscript_ = com.google.protobuf.ByteString.EMPTY;
+      baseFramework_ = "";
     }
 
     @java.lang.Override
@@ -244,6 +291,25 @@ public final class PlanOuterClass {
 
               break;
             }
+            case 74: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              baseFramework_ = s;
+              break;
+            }
+            case 82: {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                roles_ = com.google.protobuf.MapField.newMapField(
+                    RolesDefaultEntryHolder.defaultEntry);
+                mutable_bitField0_ |= 0x00000002;
+              }
+              com.google.protobuf.MapEntry<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role>
+              roles__ = input.readMessage(
+                  RolesDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
+              roles_.getMutableMap().put(
+                  roles__.getKey(), roles__.getValue());
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -271,6 +337,18 @@ public final class PlanOuterClass {
       return org.openmined.syftproto.execution.v1.PlanOuterClass.internal_static_syft_proto_execution_v1_Plan_descriptor;
     }
 
+    @SuppressWarnings({"rawtypes"})
+    @java.lang.Override
+    protected com.google.protobuf.MapField internalGetMapField(
+        int number) {
+      switch (number) {
+        case 10:
+          return internalGetRoles();
+        default:
+          throw new RuntimeException(
+              "Invalid map field number: " + number);
+      }
+    }
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
@@ -490,6 +568,125 @@ public final class PlanOuterClass {
       return getInputTypes();
     }
 
+    public static final int BASE_FRAMEWORK_FIELD_NUMBER = 9;
+    private volatile java.lang.Object baseFramework_;
+    /**
+     * <code>string base_framework = 9[json_name = "baseFramework"];</code>
+     * @return The baseFramework.
+     */
+    @java.lang.Override
+    public java.lang.String getBaseFramework() {
+      java.lang.Object ref = baseFramework_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        baseFramework_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string base_framework = 9[json_name = "baseFramework"];</code>
+     * @return The bytes for baseFramework.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getBaseFrameworkBytes() {
+      java.lang.Object ref = baseFramework_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        baseFramework_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ROLES_FIELD_NUMBER = 10;
+    private static final class RolesDefaultEntryHolder {
+      static final com.google.protobuf.MapEntry<
+          java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> defaultEntry =
+              com.google.protobuf.MapEntry
+              .<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role>newDefaultInstance(
+                  org.openmined.syftproto.execution.v1.PlanOuterClass.internal_static_syft_proto_execution_v1_Plan_RolesEntry_descriptor, 
+                  com.google.protobuf.WireFormat.FieldType.STRING,
+                  "",
+                  com.google.protobuf.WireFormat.FieldType.MESSAGE,
+                  org.openmined.syftproto.execution.v1.RoleOuterClass.Role.getDefaultInstance());
+    }
+    private com.google.protobuf.MapField<
+        java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> roles_;
+    private com.google.protobuf.MapField<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role>
+    internalGetRoles() {
+      if (roles_ == null) {
+        return com.google.protobuf.MapField.emptyMapField(
+            RolesDefaultEntryHolder.defaultEntry);
+      }
+      return roles_;
+    }
+
+    public int getRolesCount() {
+      return internalGetRoles().getMap().size();
+    }
+    /**
+     * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+     */
+
+    @java.lang.Override
+    public boolean containsRoles(
+        java.lang.String key) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      return internalGetRoles().getMap().containsKey(key);
+    }
+    /**
+     * Use {@link #getRolesMap()} instead.
+     */
+    @java.lang.Override
+    @java.lang.Deprecated
+    public java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> getRoles() {
+      return getRolesMap();
+    }
+    /**
+     * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+     */
+    @java.lang.Override
+
+    public java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> getRolesMap() {
+      return internalGetRoles().getMap();
+    }
+    /**
+     * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+     */
+    @java.lang.Override
+
+    public org.openmined.syftproto.execution.v1.RoleOuterClass.Role getRolesOrDefault(
+        java.lang.String key,
+        org.openmined.syftproto.execution.v1.RoleOuterClass.Role defaultValue) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> map =
+          internalGetRoles().getMap();
+      return map.containsKey(key) ? map.get(key) : defaultValue;
+    }
+    /**
+     * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+     */
+    @java.lang.Override
+
+    public org.openmined.syftproto.execution.v1.RoleOuterClass.Role getRolesOrThrow(
+        java.lang.String key) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> map =
+          internalGetRoles().getMap();
+      if (!map.containsKey(key)) {
+        throw new java.lang.IllegalArgumentException();
+      }
+      return map.get(key);
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -528,6 +725,15 @@ public final class PlanOuterClass {
       if (inputTypes_ != null) {
         output.writeMessage(8, getInputTypes());
       }
+      if (!getBaseFrameworkBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 9, baseFramework_);
+      }
+      com.google.protobuf.GeneratedMessageV3
+        .serializeStringMapTo(
+          output,
+          internalGetRoles(),
+          RolesDefaultEntryHolder.defaultEntry,
+          10);
       unknownFields.writeTo(output);
     }
 
@@ -571,6 +777,19 @@ public final class PlanOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(8, getInputTypes());
       }
+      if (!getBaseFrameworkBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(9, baseFramework_);
+      }
+      for (java.util.Map.Entry<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> entry
+           : internalGetRoles().getMap().entrySet()) {
+        com.google.protobuf.MapEntry<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role>
+        roles__ = RolesDefaultEntryHolder.defaultEntry.newBuilderForType()
+            .setKey(entry.getKey())
+            .setValue(entry.getValue())
+            .build();
+        size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(10, roles__);
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -611,6 +830,10 @@ public final class PlanOuterClass {
         if (!getInputTypes()
             .equals(other.getInputTypes())) return false;
       }
+      if (!getBaseFramework()
+          .equals(other.getBaseFramework())) return false;
+      if (!internalGetRoles().equals(
+          other.internalGetRoles())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -646,6 +869,12 @@ public final class PlanOuterClass {
       if (hasInputTypes()) {
         hash = (37 * hash) + INPUT_TYPES_FIELD_NUMBER;
         hash = (53 * hash) + getInputTypes().hashCode();
+      }
+      hash = (37 * hash) + BASE_FRAMEWORK_FIELD_NUMBER;
+      hash = (53 * hash) + getBaseFramework().hashCode();
+      if (!internalGetRoles().getMap().isEmpty()) {
+        hash = (37 * hash) + ROLES_FIELD_NUMBER;
+        hash = (53 * hash) + internalGetRoles().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -754,6 +983,28 @@ public final class PlanOuterClass {
         return org.openmined.syftproto.execution.v1.PlanOuterClass.internal_static_syft_proto_execution_v1_Plan_descriptor;
       }
 
+      @SuppressWarnings({"rawtypes"})
+      protected com.google.protobuf.MapField internalGetMapField(
+          int number) {
+        switch (number) {
+          case 10:
+            return internalGetRoles();
+          default:
+            throw new RuntimeException(
+                "Invalid map field number: " + number);
+        }
+      }
+      @SuppressWarnings({"rawtypes"})
+      protected com.google.protobuf.MapField internalGetMutableMapField(
+          int number) {
+        switch (number) {
+          case 10:
+            return internalGetMutableRoles();
+          default:
+            throw new RuntimeException(
+                "Invalid map field number: " + number);
+        }
+      }
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
@@ -808,6 +1059,9 @@ public final class PlanOuterClass {
           inputTypes_ = null;
           inputTypesBuilder_ = null;
         }
+        baseFramework_ = "";
+
+        internalGetMutableRoles().clear();
         return this;
       }
 
@@ -859,6 +1113,9 @@ public final class PlanOuterClass {
         } else {
           result.inputTypes_ = inputTypesBuilder_.build();
         }
+        result.baseFramework_ = baseFramework_;
+        result.roles_ = internalGetRoles();
+        result.roles_.makeImmutable();
         onBuilt();
         return result;
       }
@@ -940,6 +1197,12 @@ public final class PlanOuterClass {
         if (other.hasInputTypes()) {
           mergeInputTypes(other.getInputTypes());
         }
+        if (!other.getBaseFramework().isEmpty()) {
+          baseFramework_ = other.baseFramework_;
+          onChanged();
+        }
+        internalGetMutableRoles().mergeFrom(
+            other.internalGetRoles());
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -1653,6 +1916,210 @@ public final class PlanOuterClass {
         }
         return inputTypesBuilder_;
       }
+
+      private java.lang.Object baseFramework_ = "";
+      /**
+       * <code>string base_framework = 9[json_name = "baseFramework"];</code>
+       * @return The baseFramework.
+       */
+      public java.lang.String getBaseFramework() {
+        java.lang.Object ref = baseFramework_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          baseFramework_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string base_framework = 9[json_name = "baseFramework"];</code>
+       * @return The bytes for baseFramework.
+       */
+      public com.google.protobuf.ByteString
+          getBaseFrameworkBytes() {
+        java.lang.Object ref = baseFramework_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          baseFramework_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string base_framework = 9[json_name = "baseFramework"];</code>
+       * @param value The baseFramework to set.
+       * @return This builder for chaining.
+       */
+      public Builder setBaseFramework(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        baseFramework_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string base_framework = 9[json_name = "baseFramework"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearBaseFramework() {
+        
+        baseFramework_ = getDefaultInstance().getBaseFramework();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string base_framework = 9[json_name = "baseFramework"];</code>
+       * @param value The bytes for baseFramework to set.
+       * @return This builder for chaining.
+       */
+      public Builder setBaseFrameworkBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        baseFramework_ = value;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.MapField<
+          java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> roles_;
+      private com.google.protobuf.MapField<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role>
+      internalGetRoles() {
+        if (roles_ == null) {
+          return com.google.protobuf.MapField.emptyMapField(
+              RolesDefaultEntryHolder.defaultEntry);
+        }
+        return roles_;
+      }
+      private com.google.protobuf.MapField<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role>
+      internalGetMutableRoles() {
+        onChanged();;
+        if (roles_ == null) {
+          roles_ = com.google.protobuf.MapField.newMapField(
+              RolesDefaultEntryHolder.defaultEntry);
+        }
+        if (!roles_.isMutable()) {
+          roles_ = roles_.copy();
+        }
+        return roles_;
+      }
+
+      public int getRolesCount() {
+        return internalGetRoles().getMap().size();
+      }
+      /**
+       * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+       */
+
+      @java.lang.Override
+      public boolean containsRoles(
+          java.lang.String key) {
+        if (key == null) { throw new java.lang.NullPointerException(); }
+        return internalGetRoles().getMap().containsKey(key);
+      }
+      /**
+       * Use {@link #getRolesMap()} instead.
+       */
+      @java.lang.Override
+      @java.lang.Deprecated
+      public java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> getRoles() {
+        return getRolesMap();
+      }
+      /**
+       * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+       */
+      @java.lang.Override
+
+      public java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> getRolesMap() {
+        return internalGetRoles().getMap();
+      }
+      /**
+       * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+       */
+      @java.lang.Override
+
+      public org.openmined.syftproto.execution.v1.RoleOuterClass.Role getRolesOrDefault(
+          java.lang.String key,
+          org.openmined.syftproto.execution.v1.RoleOuterClass.Role defaultValue) {
+        if (key == null) { throw new java.lang.NullPointerException(); }
+        java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> map =
+            internalGetRoles().getMap();
+        return map.containsKey(key) ? map.get(key) : defaultValue;
+      }
+      /**
+       * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+       */
+      @java.lang.Override
+
+      public org.openmined.syftproto.execution.v1.RoleOuterClass.Role getRolesOrThrow(
+          java.lang.String key) {
+        if (key == null) { throw new java.lang.NullPointerException(); }
+        java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> map =
+            internalGetRoles().getMap();
+        if (!map.containsKey(key)) {
+          throw new java.lang.IllegalArgumentException();
+        }
+        return map.get(key);
+      }
+
+      public Builder clearRoles() {
+        internalGetMutableRoles().getMutableMap()
+            .clear();
+        return this;
+      }
+      /**
+       * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+       */
+
+      public Builder removeRoles(
+          java.lang.String key) {
+        if (key == null) { throw new java.lang.NullPointerException(); }
+        internalGetMutableRoles().getMutableMap()
+            .remove(key);
+        return this;
+      }
+      /**
+       * Use alternate mutation accessors instead.
+       */
+      @java.lang.Deprecated
+      public java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role>
+      getMutableRoles() {
+        return internalGetMutableRoles().getMutableMap();
+      }
+      /**
+       * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+       */
+      public Builder putRoles(
+          java.lang.String key,
+          org.openmined.syftproto.execution.v1.RoleOuterClass.Role value) {
+        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (value == null) { throw new java.lang.NullPointerException(); }
+        internalGetMutableRoles().getMutableMap()
+            .put(key, value);
+        return this;
+      }
+      /**
+       * <code>map&lt;string, .syft_proto.execution.v1.Role&gt; roles = 10[json_name = "roles"];</code>
+       */
+
+      public Builder putAllRoles(
+          java.util.Map<java.lang.String, org.openmined.syftproto.execution.v1.RoleOuterClass.Role> values) {
+        internalGetMutableRoles().getMutableMap()
+            .putAll(values);
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -1711,6 +2178,11 @@ public final class PlanOuterClass {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_syft_proto_execution_v1_Plan_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_syft_proto_execution_v1_Plan_RolesEntry_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_syft_proto_execution_v1_Plan_RolesEntry_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -1724,7 +2196,7 @@ public final class PlanOuterClass {
       "ft_proto.execution.v1\032\"syft_proto/execut" +
       "ion/v1/role.proto\032!syft_proto/types/syft" +
       "/v1/id.proto\032*syft_proto/execution/v1/ty" +
-      "pe_wrapper.proto\"\305\002\n\004Plan\022,\n\002id\030\001 \001(\0132\034." +
+      "pe_wrapper.proto\"\205\004\n\004Plan\022,\n\002id\030\001 \001(\0132\034." +
       "syft_proto.types.syft.v1.IdR\002id\0221\n\004role\030" +
       "\002 \001(\0132\035.syft_proto.execution.v1.RoleR\004ro" +
       "le\022#\n\rinclude_state\030\003 \001(\010R\014includeState\022" +
@@ -1732,8 +2204,13 @@ public final class PlanOuterClass {
       " \n\013description\030\006 \001(\tR\013description\022 \n\013tor" +
       "chscript\030\007 \001(\014R\013torchscript\022K\n\013input_typ" +
       "es\030\010 \001(\0132*.syft_proto.execution.v1.Neste" +
-      "dTypeWrapperR\ninputTypesB&\n$org.openmine" +
-      "d.syftproto.execution.v1b\006proto3"
+      "dTypeWrapperR\ninputTypes\022%\n\016base_framewo" +
+      "rk\030\t \001(\tR\rbaseFramework\022>\n\005roles\030\n \003(\0132(" +
+      ".syft_proto.execution.v1.Plan.RolesEntry" +
+      "R\005roles\032W\n\nRolesEntry\022\020\n\003key\030\001 \001(\tR\003key\022" +
+      "3\n\005value\030\002 \001(\0132\035.syft_proto.execution.v1" +
+      ".RoleR\005value:\0028\001B&\n$org.openmined.syftpr" +
+      "oto.execution.v1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -1747,7 +2224,13 @@ public final class PlanOuterClass {
     internal_static_syft_proto_execution_v1_Plan_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_syft_proto_execution_v1_Plan_descriptor,
-        new java.lang.String[] { "Id", "Role", "IncludeState", "Name", "Tags", "Description", "Torchscript", "InputTypes", });
+        new java.lang.String[] { "Id", "Role", "IncludeState", "Name", "Tags", "Description", "Torchscript", "InputTypes", "BaseFramework", "Roles", });
+    internal_static_syft_proto_execution_v1_Plan_RolesEntry_descriptor =
+      internal_static_syft_proto_execution_v1_Plan_descriptor.getNestedTypes().get(0);
+    internal_static_syft_proto_execution_v1_Plan_RolesEntry_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_syft_proto_execution_v1_Plan_RolesEntry_descriptor,
+        new java.lang.String[] { "Key", "Value", });
     org.openmined.syftproto.execution.v1.RoleOuterClass.getDescriptor();
     org.openmined.syftproto.types.syft.v1.IdOuterClass.getDescriptor();
     org.openmined.syftproto.execution.v1.TypeWrapper.getDescriptor();

--- a/protobuf/syft_proto/execution/v1/plan.proto
+++ b/protobuf/syft_proto/execution/v1/plan.proto
@@ -16,4 +16,6 @@ message Plan {
     string description = 6;
     bytes torchscript = 7;
     NestedTypeWrapper input_types = 8;
+    string base_framework = 9;
+    map<string, syft_proto.execution.v1.Role> roles = 10;
 }

--- a/swift/syft_proto/execution/v1/plan.pb.swift
+++ b/swift/syft_proto/execution/v1/plan.pb.swift
@@ -62,6 +62,10 @@ public struct SyftProto_Execution_V1_Plan {
   /// Clears the value of `inputTypes`. Subsequent reads from it will return its default value.
   public mutating func clearInputTypes() {self._inputTypes = nil}
 
+  public var baseFramework: String = String()
+
+  public var roles: Dictionary<String,SyftProto_Execution_V1_Role> = [:]
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -86,6 +90,8 @@ extension SyftProto_Execution_V1_Plan: SwiftProtobuf.Message, SwiftProtobuf._Mes
     6: .same(proto: "description"),
     7: .same(proto: "torchscript"),
     8: .standard(proto: "input_types"),
+    9: .standard(proto: "base_framework"),
+    10: .same(proto: "roles"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -99,6 +105,8 @@ extension SyftProto_Execution_V1_Plan: SwiftProtobuf.Message, SwiftProtobuf._Mes
       case 6: try decoder.decodeSingularStringField(value: &self.description_p)
       case 7: try decoder.decodeSingularBytesField(value: &self.torchscript)
       case 8: try decoder.decodeSingularMessageField(value: &self._inputTypes)
+      case 9: try decoder.decodeSingularStringField(value: &self.baseFramework)
+      case 10: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,SyftProto_Execution_V1_Role>.self, value: &self.roles)
       default: break
       }
     }
@@ -129,6 +137,12 @@ extension SyftProto_Execution_V1_Plan: SwiftProtobuf.Message, SwiftProtobuf._Mes
     if let v = self._inputTypes {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
     }
+    if !self.baseFramework.isEmpty {
+      try visitor.visitSingularStringField(value: self.baseFramework, fieldNumber: 9)
+    }
+    if !self.roles.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,SyftProto_Execution_V1_Role>.self, value: self.roles, fieldNumber: 10)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -141,6 +155,8 @@ extension SyftProto_Execution_V1_Plan: SwiftProtobuf.Message, SwiftProtobuf._Mes
     if lhs.description_p != rhs.description_p {return false}
     if lhs.torchscript != rhs.torchscript {return false}
     if lhs._inputTypes != rhs._inputTypes {return false}
+    if lhs.baseFramework != rhs.baseFramework {return false}
+    if lhs.roles != rhs.roles {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/syft_proto/execution/v1/plan_pb2.py
+++ b/syft_proto/execution/v1/plan_pb2.py
@@ -22,12 +22,50 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=b'\n$org.openmined.syftproto.execution.v1',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\"syft_proto/execution/v1/plan.proto\x12\x17syft_proto.execution.v1\x1a\"syft_proto/execution/v1/role.proto\x1a!syft_proto/types/syft/v1/id.proto\x1a*syft_proto/execution/v1/type_wrapper.proto\"\xc5\x02\n\x04Plan\x12,\n\x02id\x18\x01 \x01(\x0b\x32\x1c.syft_proto.types.syft.v1.IdR\x02id\x12\x31\n\x04role\x18\x02 \x01(\x0b\x32\x1d.syft_proto.execution.v1.RoleR\x04role\x12#\n\rinclude_state\x18\x03 \x01(\x08R\x0cincludeState\x12\x12\n\x04name\x18\x04 \x01(\tR\x04name\x12\x12\n\x04tags\x18\x05 \x03(\tR\x04tags\x12 \n\x0b\x64\x65scription\x18\x06 \x01(\tR\x0b\x64\x65scription\x12 \n\x0btorchscript\x18\x07 \x01(\x0cR\x0btorchscript\x12K\n\x0binput_types\x18\x08 \x01(\x0b\x32*.syft_proto.execution.v1.NestedTypeWrapperR\ninputTypesB&\n$org.openmined.syftproto.execution.v1b\x06proto3'
+  serialized_pb=b'\n\"syft_proto/execution/v1/plan.proto\x12\x17syft_proto.execution.v1\x1a\"syft_proto/execution/v1/role.proto\x1a!syft_proto/types/syft/v1/id.proto\x1a*syft_proto/execution/v1/type_wrapper.proto\"\x85\x04\n\x04Plan\x12,\n\x02id\x18\x01 \x01(\x0b\x32\x1c.syft_proto.types.syft.v1.IdR\x02id\x12\x31\n\x04role\x18\x02 \x01(\x0b\x32\x1d.syft_proto.execution.v1.RoleR\x04role\x12#\n\rinclude_state\x18\x03 \x01(\x08R\x0cincludeState\x12\x12\n\x04name\x18\x04 \x01(\tR\x04name\x12\x12\n\x04tags\x18\x05 \x03(\tR\x04tags\x12 \n\x0b\x64\x65scription\x18\x06 \x01(\tR\x0b\x64\x65scription\x12 \n\x0btorchscript\x18\x07 \x01(\x0cR\x0btorchscript\x12K\n\x0binput_types\x18\x08 \x01(\x0b\x32*.syft_proto.execution.v1.NestedTypeWrapperR\ninputTypes\x12%\n\x0e\x62\x61se_framework\x18\t \x01(\tR\rbaseFramework\x12>\n\x05roles\x18\n \x03(\x0b\x32(.syft_proto.execution.v1.Plan.RolesEntryR\x05roles\x1aW\n\nRolesEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x33\n\x05value\x18\x02 \x01(\x0b\x32\x1d.syft_proto.execution.v1.RoleR\x05value:\x02\x38\x01\x42&\n$org.openmined.syftproto.execution.v1b\x06proto3'
   ,
   dependencies=[syft__proto_dot_execution_dot_v1_dot_role__pb2.DESCRIPTOR,syft__proto_dot_types_dot_syft_dot_v1_dot_id__pb2.DESCRIPTOR,syft__proto_dot_execution_dot_v1_dot_type__wrapper__pb2.DESCRIPTOR,])
 
 
 
+
+_PLAN_ROLESENTRY = _descriptor.Descriptor(
+  name='RolesEntry',
+  full_name='syft_proto.execution.v1.Plan.RolesEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='syft_proto.execution.v1.Plan.RolesEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, json_name='key', file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='syft_proto.execution.v1.Plan.RolesEntry.value', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, json_name='value', file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=b'8\001',
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=609,
+  serialized_end=696,
+)
 
 _PLAN = _descriptor.Descriptor(
   name='Plan',
@@ -93,10 +131,24 @@ _PLAN = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, json_name='inputTypes', file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='base_framework', full_name='syft_proto.execution.v1.Plan.base_framework', index=8,
+      number=9, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, json_name='baseFramework', file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='roles', full_name='syft_proto.execution.v1.Plan.roles', index=9,
+      number=10, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, json_name='roles', file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
-  nested_types=[],
+  nested_types=[_PLAN_ROLESENTRY, ],
   enum_types=[
   ],
   serialized_options=None,
@@ -106,22 +158,34 @@ _PLAN = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=179,
-  serialized_end=504,
+  serialized_end=696,
 )
 
+_PLAN_ROLESENTRY.fields_by_name['value'].message_type = syft__proto_dot_execution_dot_v1_dot_role__pb2._ROLE
+_PLAN_ROLESENTRY.containing_type = _PLAN
 _PLAN.fields_by_name['id'].message_type = syft__proto_dot_types_dot_syft_dot_v1_dot_id__pb2._ID
 _PLAN.fields_by_name['role'].message_type = syft__proto_dot_execution_dot_v1_dot_role__pb2._ROLE
 _PLAN.fields_by_name['input_types'].message_type = syft__proto_dot_execution_dot_v1_dot_type__wrapper__pb2._NESTEDTYPEWRAPPER
+_PLAN.fields_by_name['roles'].message_type = _PLAN_ROLESENTRY
 DESCRIPTOR.message_types_by_name['Plan'] = _PLAN
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 Plan = _reflection.GeneratedProtocolMessageType('Plan', (_message.Message,), {
+
+  'RolesEntry' : _reflection.GeneratedProtocolMessageType('RolesEntry', (_message.Message,), {
+    'DESCRIPTOR' : _PLAN_ROLESENTRY,
+    '__module__' : 'syft_proto.execution.v1.plan_pb2'
+    # @@protoc_insertion_point(class_scope:syft_proto.execution.v1.Plan.RolesEntry)
+    })
+  ,
   'DESCRIPTOR' : _PLAN,
   '__module__' : 'syft_proto.execution.v1.plan_pb2'
   # @@protoc_insertion_point(class_scope:syft_proto.execution.v1.Plan)
   })
 _sym_db.RegisterMessage(Plan)
+_sym_db.RegisterMessage(Plan.RolesEntry)
 
 
 DESCRIPTOR._options = None
+_PLAN_ROLESENTRY._options = None
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
## Description
Adds `base_framework` and `roles` to Plan, this is required to serialize Plans with multiple roles (translations of role).

## Affected Dependencies
n/a

## How has this been tested?
Will be tested in PySyft, PR: ...

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
