### PR TITLE
Tensor name change: FVTensor -> BFVTensor

### DIFF
--- a/proto.json
+++ b/proto.json
@@ -214,7 +214,7 @@
     "syft.execution.role_assignments.RoleAssignments": {
       "code": 65
     },
-    "syft.frameworks.torch.tensors.interpreters.fv.FVTensor": {
+    "syft.frameworks.torch.tensors.interpreters.bfv.BFVTensor": {
       "code": 66
     },
     "syft.execution.storage_actions.StorageAction": {


### PR DESCRIPTION
## Description
Name change of tensor, As this scheme is known by both names (FV, BFV) but BFVTensor would be better than just FV.

## Affected Dependencies
Not sure😓

## How has this been tested?
Not tested

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
