### PR TITLE
Add code for EmptyCryptoPrimitiveStoreError

### DIFF
--- a/proto.json
+++ b/proto.json
@@ -222,6 +222,9 @@
     },
     "syft.frameworks.crypten.model.OnnxModel": {
       "code": 68
+    },
+    "syft.exceptions.EmptyCryptoPrimitiveStoreError": {
+      "code": 69
     }
   }
 }


### PR DESCRIPTION
This is an exception used for Function Secret SHaring