### PR TITLE
ADD DataCentricFLClient as a serializable syft object

### DIFF
--- a/proto.json
+++ b/proto.json
@@ -225,6 +225,10 @@
     },
     "syft.exceptions.EmptyCryptoPrimitiveStoreError": {
       "code": 69
+    },
+    "syft.grid.clients.data_centric_fl_client.DataCentricFLClient": {
+      "code": 70,
+      "forced_code": 71
     }
   }
 }


### PR DESCRIPTION
## Description
Add DataCentricFLCLient type into the serializable objects list.



## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
